### PR TITLE
add endpoint option for S3 compatible providers

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -11,8 +11,7 @@
 		},
 		{
 			"ImportPath": "github.com/concourse/s3gof3r",
-			"Comment": "v0.4.10-6-ga0ce373",
-			"Rev": "a0ce37354614537c22db2db58bb52ce6a8aeaf0d"
+			"Rev": "da1d67eb2aee49f5c133d0323372f5baaaa0e4da"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/go-version",

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ URLs provided are signed.
 distribution that is fronting this bucket. This will be used in the `url` file
 that is given to the following task.
 
+* `endpoint`: *Optional.* Custom endpoint for using S3 compatible provider.
+
+* `disable_md5_hash_check`: *Optional.* Disables MD5 hash checking of files while uploading/downloading.
+
 ## Behavior
 
 ### `check`: Extract versions from the bucket.

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -16,6 +16,8 @@ func main() {
 		request.Source.AccessKeyID,
 		request.Source.SecretAccessKey,
 		request.Source.RegionName,
+		request.Source.Endpoint,
+		!request.Source.DisableMD5HashCheck,
 	)
 	if err != nil {
 		s3resource.Fatal("building S3 client", err)

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -23,6 +23,8 @@ func main() {
 		request.Source.AccessKeyID,
 		request.Source.SecretAccessKey,
 		request.Source.RegionName,
+		request.Source.Endpoint,
+		!request.Source.DisableMD5HashCheck,
 	)
 	if err != nil {
 		s3resource.Fatal("building S3 client", err)

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -23,6 +23,8 @@ func main() {
 		request.Source.AccessKeyID,
 		request.Source.SecretAccessKey,
 		request.Source.RegionName,
+		request.Source.Endpoint,
+		!request.Source.DisableMD5HashCheck,
 	)
 	if err != nil {
 		s3resource.Fatal("building S3 client", err)

--- a/models.go
+++ b/models.go
@@ -1,13 +1,15 @@
 package s3resource
 
 type Source struct {
-	AccessKeyID     string `json:"access_key_id"`
-	SecretAccessKey string `json:"secret_access_key"`
-	Bucket          string `json:"bucket"`
-	Regexp          string `json:"regexp"`
-	Private         bool   `json:"private"`
-	RegionName      string `json:"region_name"`
-	CloudfrontURL   string `json:"cloudfront_url"`
+	AccessKeyID         string `json:"access_key_id"`
+	SecretAccessKey     string `json:"secret_access_key"`
+	Bucket              string `json:"bucket"`
+	Regexp              string `json:"regexp"`
+	Private             bool   `json:"private"`
+	RegionName          string `json:"region_name"`
+	CloudfrontURL       string `json:"cloudfront_url"`
+	Endpoint            string `json:"endpoint"`
+	DisableMD5HashCheck bool   `json:"disable_md5_hash_check"`
 }
 
 type Version struct {

--- a/out/out_command.go
+++ b/out/out_command.go
@@ -74,7 +74,7 @@ func (command *OutCommand) match(sourceDir, pattern string) (string, error) {
 	}
 
 	if len(matches) > 1 {
-		return "", fmt.Errorf("more than one match found for pattern: %s", pattern)
+		return "", fmt.Errorf("more than one match found for pattern: %s\n%v", pattern, matches)
 	}
 
 	return matches[0], nil


### PR DESCRIPTION
Adds an option to specify a custom S3 compatible endpoint.

Additionally there's also an option to disable md5 hash checking on files, as some S3 providers might have a problem with this. (Mine did) 
Relies on this PR concourse/s3gof3r/pull/1

Default behaviour for AWS stays the same as before.

Signed-off-by: Fabio Berchtold <fabio.berchtold@swisscom.com>