### PR TITLE
Support local s3 for development

### DIFF
--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -21,6 +21,7 @@ var secretAccessKey = os.Getenv("S3_TESTING_SECRET_ACCESS_KEY")
 var versionedBucketName = os.Getenv("S3_VERSIONED_TESTING_BUCKET")
 var bucketName = os.Getenv("S3_TESTING_BUCKET")
 var regionName = os.Getenv("S3_TESTING_REGION")
+var endpoint = os.Getenv("S3_ENDPOINT")
 var s3client s3resource.S3Client
 
 var checkPath string
@@ -69,7 +70,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		accessKeyID,
 		secretAccessKey,
 		regionName,
-		"",
+		endpoint,
 	)
 })
 

--- a/integration/out_test.go
+++ b/integration/out_test.go
@@ -64,6 +64,7 @@ var _ = Describe("out", func() {
 					RegionName:      regionName,
 					Regexp:          "some-regex",
 					VersionedFile:   "some-file",
+					Endpoint:        endpoint,
 				},
 			}
 
@@ -101,6 +102,7 @@ var _ = Describe("out", func() {
 						SecretAccessKey: secretAccessKey,
 						Bucket:          bucketName,
 						RegionName:      regionName,
+						Endpoint:        endpoint,
 					},
 					Params: out.Params{
 						From: "file-to-upload",
@@ -135,7 +137,7 @@ var _ = Describe("out", func() {
 						},
 						{
 							Name:  "url",
-							Value: buildEndpoint(bucketName, "") + directoryPrefix + "/file-to-upload",
+							Value: buildEndpoint(bucketName, endpoint) + directoryPrefix + "/file-to-upload",
 						},
 					},
 				}))
@@ -154,6 +156,7 @@ var _ = Describe("out", func() {
 						Bucket:          bucketName,
 						RegionName:      regionName,
 						VersionedFile:   filepath.Join(directoryPrefix, "file-to-upload"),
+						Endpoint:        endpoint,
 					},
 					Params: out.Params{
 						From: "file-to-upload-local",
@@ -203,6 +206,7 @@ var _ = Describe("out", func() {
 						Bucket:          versionedBucketName,
 						RegionName:      regionName,
 						VersionedFile:   filepath.Join(directoryPrefix, "file-to-upload"),
+						Endpoint:        endpoint,
 					},
 					Params: out.Params{
 						From: "file-to-upload-local",
@@ -240,7 +244,7 @@ var _ = Describe("out", func() {
 						},
 						{
 							Name:  "url",
-							Value: buildEndpoint(versionedBucketName, "") + directoryPrefix + "/file-to-upload?versionId=" + versions[0],
+							Value: buildEndpoint(versionedBucketName, endpoint) + directoryPrefix + "/file-to-upload?versionId=" + versions[0],
 						},
 					},
 				}))
@@ -258,6 +262,7 @@ var _ = Describe("out", func() {
 						SecretAccessKey: secretAccessKey,
 						Bucket:          versionedBucketName,
 						RegionName:      regionName,
+						Endpoint:        endpoint,
 					},
 					Params: out.Params{
 						From: "file-to-upload",
@@ -295,7 +300,7 @@ var _ = Describe("out", func() {
 						},
 						{
 							Name:  "url",
-							Value: buildEndpoint(versionedBucketName, "") + directoryPrefix + "/file-to-upload?versionId=" + versions[0],
+							Value: buildEndpoint(versionedBucketName, endpoint) + directoryPrefix + "/file-to-upload?versionId=" + versions[0],
 						},
 					},
 				}))
@@ -304,6 +309,10 @@ var _ = Describe("out", func() {
 	})
 })
 
-func buildEndpoint(bucket string, _ string) string {
-	return "https://" + bucket + ".s3.amazonaws.com/"
+func buildEndpoint(bucket string, endpoint string) string {
+	if endpoint == "" {
+		return "https://s3.amazonaws.com/" + bucket + "/"
+	} else {
+		return endpoint + "/" + bucket + "/"
+	}
 }

--- a/integration/out_test.go
+++ b/integration/out_test.go
@@ -135,7 +135,7 @@ var _ = Describe("out", func() {
 						},
 						{
 							Name:  "url",
-							Value: "https://" + bucketName + ".s3.amazonaws.com/" + directoryPrefix + "/file-to-upload",
+							Value: buildEndpoint(bucketName, "") + directoryPrefix + "/file-to-upload",
 						},
 					},
 				}))
@@ -240,7 +240,7 @@ var _ = Describe("out", func() {
 						},
 						{
 							Name:  "url",
-							Value: "https://" + versionedBucketName + ".s3.amazonaws.com/" + directoryPrefix + "/file-to-upload?versionId=" + versions[0],
+							Value: buildEndpoint(versionedBucketName, "") + directoryPrefix + "/file-to-upload?versionId=" + versions[0],
 						},
 					},
 				}))
@@ -295,7 +295,7 @@ var _ = Describe("out", func() {
 						},
 						{
 							Name:  "url",
-							Value: "https://" + versionedBucketName + ".s3.amazonaws.com/" + directoryPrefix + "/file-to-upload?versionId=" + versions[0],
+							Value: buildEndpoint(versionedBucketName, "") + directoryPrefix + "/file-to-upload?versionId=" + versions[0],
 						},
 					},
 				}))
@@ -303,3 +303,7 @@ var _ = Describe("out", func() {
 		})
 	})
 })
+
+func buildEndpoint(bucket string, _ string) string {
+	return "https://" + bucket + ".s3.amazonaws.com/"
+}

--- a/s3client.go
+++ b/s3client.go
@@ -45,12 +45,13 @@ func NewS3Client(accessKey string, secretKey string, regionName string, endpoint
 	}
 
 	awsConfig := &aws.Config{
-		Region:      &regionName,
-		Credentials: creds,
+		Region:           &regionName,
+		Credentials:      creds,
+		S3ForcePathStyle: aws.Bool(true),
 	}
 
 	if len(endpoint) != 0 {
-		endpoint := fmt.Sprintf("https://%s", endpoint)
+		endpoint := fmt.Sprintf("%s", endpoint)
 		awsConfig.Endpoint = &endpoint
 	}
 


### PR DESCRIPTION
This change adds support for non-ssl s3 endpoints. It also forces path-style for easier setup for local development.