### PR TITLE
Retrieve credentials from instance profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ version numbers.
 
 ## Source Configuration
 
-* `access_key_id`: *Required.* The AWS access key to use when accessing the
-  bucket.
+* `access_key_id`: *Optional.* The AWS access key to use when accessing the
+  bucket. If empty, the resource will try to retrieve credentials from
+  [AWS instance profile](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html)
 
-* `secret_access_key`: *Required.* The AWS secret key to use when accessing
-  the bucket.
+* `secret_access_key`: *Optional.* The AWS secret key to use when accessing
+  the bucket. If empty, the resource will try to retrieve credentials from
+  [AWS instance profile](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html)
 
 * `bucket`: *Required.* The name of the bucket.
 

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -17,6 +17,7 @@ func TestIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
 }
 
+var useInstanceProfile = os.Getenv("S3_USE_INSTANCE_PROFILE")
 var accessKeyID = os.Getenv("S3_TESTING_ACCESS_KEY_ID")
 var secretAccessKey = os.Getenv("S3_TESTING_SECRET_ACCESS_KEY")
 var versionedBucketName = os.Getenv("S3_VERSIONED_TESTING_BUCKET")
@@ -61,8 +62,12 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	inPath = sd.InPath
 	outPath = sd.OutPath
 
-	Ω(accessKeyID).ShouldNot(BeEmpty(), "must specify $S3_TESTING_ACCESS_KEY_ID")
-	Ω(secretAccessKey).ShouldNot(BeEmpty(), "must specify $S3_TESTING_SECRET_ACCESS_KEY")
+	if useInstanceProfile == "" {
+		Ω(accessKeyID).ShouldNot(BeEmpty(),
+			"must specify $S3_TESTING_ACCESS_KEY_ID or $S3_USE_INSTANCE_PROFILE=true")
+		Ω(secretAccessKey).ShouldNot(BeEmpty(),
+			"must specify $S3_TESTING_SECRET_ACCESS_KEY or $S3_USE_INSTANCE_PROFILE=true")
+	}
 	Ω(versionedBucketName).ShouldNot(BeEmpty(), "must specify $S3_VERSIONED_TESTING_BUCKET")
 	Ω(bucketName).ShouldNot(BeEmpty(), "must specify $S3_TESTING_BUCKET")
 	Ω(regionName).ShouldNot(BeEmpty(), "must specify $S3_TESTING_REGION")

--- a/s3client.go
+++ b/s3client.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
@@ -46,10 +48,20 @@ func NewS3Client(
 ) (S3Client, error) {
 	var creds *credentials.Credentials
 
-	if accessKey == "" && secretKey == "" {
-		creds = credentials.AnonymousCredentials
-	} else {
+	if accessKey != "" || secretKey != "" {
 		creds = credentials.NewStaticCredentials(accessKey, secretKey, "")
+	} else {
+		// Try with instance profile
+		creds := credentials.NewCredentials(
+			&ec2rolecreds.EC2RoleProvider{
+				Client: ec2metadata.New(session.New()),
+			})
+		cred_details, _ := creds.Get()
+
+		// If unsuccessful fall back to anonymous
+		if cred_details == (credentials.Value{}) {
+			creds = credentials.AnonymousCredentials
+		}
 	}
 
 	if len(regionName) == 0 {


### PR DESCRIPTION
# What
Adds option to retrieve AWS credentials from [instance profile](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html). This avoids hard coding AWS keys and greatly reduces the security risks.

Solves issue https://github.com/concourse/s3-resource/issues/20.

# How to review
This can be tested on an AWS instance with the right profile

* [Install go](https://golang.org/doc/install)
* Build

```
$ scripts/build
```

* Write a test JSON, pointing to an existing file in a bucket the role has access to:

```
{
 "source": {
   "bucket": "[bucket name]",
   "versioned_file": "[file]",
   "region_name": "[region]"
 }
}
```

* Test:

```
$ cat test-profile.json | ./built-check 
[{"version_id":"qLKI5ZfFKVmNX0SgbHgF_WggU9uA.dAC"}]
$ cat test-profile.json | ./built-in .
1.44 KB / 1.44 KB [======================================] 100.00 % 14.20 KB/s 0{"version":{},"metadata":[{"name":"filename","value":"concourse-state.json"},{"name":"url","value":"https://s3-eu-west-1.amazonaws.com/hectorcolin-state/concourse-state.json"}]}
$ cat test-profile.json | ./built-out ./concourse-state.json 
1.45 KB / 1.45 KB [=======================================] 100.00 % 3.92 KB/s 0{"version":{"version_id":"FC0rWcQp7_p0Y9zJBdrC6NrBeB748xuN"},"metadata":[{"name":"filename","value":"concourse-state.json"},{"name":"url","value":"https://s3-eu-west-1.amazonaws.com/hectorcolin-state/concourse-state.json?versionId=FC0rWcQp7_p0Y9zJBdrC6NrBeB748xuN"}]}
```

* Integration tests can be run on an AWS instance with the right profile using the S3_USE_INSTANCE_PROFILE environment variable. AWS keys are not required anymore.

```
$ cd integration
$ S3_USE_INSTANCE_PROFILE=true ginkgo
```