### PR TITLE
Create an acl param for puts

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ a new version of that file.
   in the resource definition. The matching syntax is bash glob expansion, so
   no capture groups, etc.
 
+* `acl`: (optional) [Canned Acl](http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html)
+  for the uploaded object.
+
 ## Example Configuration
 
 ### Resource
@@ -107,6 +110,7 @@ a new version of that file.
 - put: release
   params:
     file: path/to/release-*.tgz
+    acl: public-read
 ```
 
 ## Required IAM Permissions
@@ -114,6 +118,7 @@ a new version of that file.
 ### Non-versioned Buckets
 
 * `s3:PutObject`
+* `s3:PutObjectAcl`
 * `s3:GetObject`
 * `s3:ListBucket`
 
@@ -124,6 +129,7 @@ Everything above and...
 * `s3:GetBucketVersioning`
 * `s3:GetObjectVersion`
 * `s3:ListBucketVersions`
+* `s3:PutObjectVersionAcl`
 
 ## Developing on this resource
 

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -12,12 +12,16 @@ func main() {
 	var request check.CheckRequest
 	inputRequest(&request)
 
-	client, err := s3resource.NewS3Client(
-		os.Stderr,
+	awsConfig, err := s3resource.NewAwsConfig(
 		request.Source.AccessKeyID,
 		request.Source.SecretAccessKey,
 		request.Source.RegionName,
 		request.Source.Endpoint,
+	)
+
+	client, err := s3resource.NewS3Client(
+		os.Stderr,
+		awsConfig,
 	)
 	if err != nil {
 		s3resource.Fatal("building S3 client", err)

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -19,12 +19,16 @@ func main() {
 	var request in.InRequest
 	inputRequest(&request)
 
-	client, err := s3resource.NewS3Client(
-		os.Stderr,
+	awsConfig, err := s3resource.NewAwsConfig(
 		request.Source.AccessKeyID,
 		request.Source.SecretAccessKey,
 		request.Source.RegionName,
 		request.Source.Endpoint,
+	)
+
+	client, err := s3resource.NewS3Client(
+		os.Stderr,
+		awsConfig,
 	)
 	if err != nil {
 		s3resource.Fatal("building S3 client", err)

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -19,12 +19,16 @@ func main() {
 
 	sourceDir := os.Args[1]
 
-	client, err := s3resource.NewS3Client(
-		os.Stderr,
+	awsConfig, err := s3resource.NewAwsConfig(
 		request.Source.AccessKeyID,
 		request.Source.SecretAccessKey,
 		request.Source.RegionName,
 		request.Source.Endpoint,
+	)
+
+	client, err := s3resource.NewS3Client(
+		os.Stderr,
+		awsConfig,
 	)
 	if err != nil {
 		s3resource.Fatal("building S3 client", err)

--- a/fakes/fake_s3client.go
+++ b/fakes/fake_s3client.go
@@ -39,6 +39,18 @@ type FakeS3Client struct {
 		result1 string
 		result2 error
 	}
+	UploadFileWithAclStub        func(bucketName string, remotePath string, localPath string, acl string) (string, error)
+	uploadFileWithAclMutex       sync.RWMutex
+	uploadFileWithAclArgsForCall []struct {
+		bucketName string
+		remotePath string
+		localPath  string
+		acl        string
+	}
+	uploadFileWithAclReturns struct {
+		result1 string
+		result2 error
+	}
 	DownloadFileStub        func(bucketName string, remotePath string, versionID string, localPath string) error
 	downloadFileMutex       sync.RWMutex
 	downloadFileArgsForCall []struct {
@@ -180,6 +192,42 @@ func (fake *FakeS3Client) UploadFileArgsForCall(i int) (string, string, string) 
 func (fake *FakeS3Client) UploadFileReturns(result1 string, result2 error) {
 	fake.UploadFileStub = nil
 	fake.uploadFileReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeS3Client) UploadFileWithAcl(bucketName string, remotePath string, localPath string, acl string) (string, error) {
+	fake.uploadFileWithAclMutex.Lock()
+	fake.uploadFileWithAclArgsForCall = append(fake.uploadFileWithAclArgsForCall, struct {
+		bucketName string
+		remotePath string
+		localPath  string
+		acl        string
+	}{bucketName, remotePath, localPath, acl})
+	fake.uploadFileWithAclMutex.Unlock()
+	if fake.UploadFileWithAclStub != nil {
+		return fake.UploadFileWithAclStub(bucketName, remotePath, localPath, acl)
+	} else {
+		return fake.uploadFileWithAclReturns.result1, fake.uploadFileWithAclReturns.result2
+	}
+}
+
+func (fake *FakeS3Client) UploadFileWithAclCallCount() int {
+	fake.uploadFileWithAclMutex.RLock()
+	defer fake.uploadFileWithAclMutex.RUnlock()
+	return len(fake.uploadFileWithAclArgsForCall)
+}
+
+func (fake *FakeS3Client) UploadFileWithAclArgsForCall(i int) (string, string, string, string) {
+	fake.uploadFileWithAclMutex.RLock()
+	defer fake.uploadFileWithAclMutex.RUnlock()
+	return fake.uploadFileWithAclArgsForCall[i].bucketName, fake.uploadFileWithAclArgsForCall[i].remotePath, fake.uploadFileWithAclArgsForCall[i].localPath, fake.uploadFileWithAclArgsForCall[i].acl
+}
+
+func (fake *FakeS3Client) UploadFileWithAclReturns(result1 string, result2 error) {
+	fake.UploadFileWithAclStub = nil
+	fake.uploadFileWithAclReturns = struct {
 		result1 string
 		result2 error
 	}{result1, result2}

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/concourse/s3-resource"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -24,6 +26,7 @@ var bucketName = os.Getenv("S3_TESTING_BUCKET")
 var regionName = os.Getenv("S3_TESTING_REGION")
 var endpoint = os.Getenv("S3_ENDPOINT")
 var s3client s3resource.S3Client
+var s3Service *s3.S3
 
 var checkPath string
 var inPath string
@@ -73,6 +76,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		regionName,
 		endpoint,
 	)
+
+	s3Service = s3.New(session.New(awsConfig), awsConfig)
 
 	s3client, err = s3resource.NewS3Client(
 		ioutil.Discard,

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -67,12 +67,16 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Ω(bucketName).ShouldNot(BeEmpty(), "must specify $S3_TESTING_BUCKET")
 	Ω(regionName).ShouldNot(BeEmpty(), "must specify $S3_TESTING_REGION")
 
-	s3client, err = s3resource.NewS3Client(
-		ioutil.Discard,
+	awsConfig, err := s3resource.NewAwsConfig(
 		accessKeyID,
 		secretAccessKey,
 		regionName,
 		endpoint,
+	)
+
+	s3client, err = s3resource.NewS3Client(
+		ioutil.Discard,
+		awsConfig,
 	)
 })
 

--- a/integration/out_test.go
+++ b/integration/out_test.go
@@ -123,7 +123,7 @@ var _ = Describe("out", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 		})
 
-		Context("with a file glob", func() {
+		Context("with a file glob and acls specified", func() {
 			BeforeEach(func() {
 				err := ioutil.WriteFile(filepath.Join(sourceDir, "glob-file-to-upload"), []byte("contents"), 0755)
 				Ω(err).ShouldNot(HaveOccurred())
@@ -139,6 +139,7 @@ var _ = Describe("out", func() {
 					Params: out.Params{
 						File: "glob-*",
 						To:   directoryPrefix + "/",
+						Acl:  "public-read",
 					},
 				}
 

--- a/out/models.go
+++ b/out/models.go
@@ -13,6 +13,7 @@ type Params struct {
 	From string `json:"from"`
 	File string `json:"file"`
 	To   string `json:"to"`
+	Acl  string `json:"acl"`
 }
 
 type OutResponse struct {

--- a/out/out_command.go
+++ b/out/out_command.go
@@ -55,22 +55,17 @@ func (command *OutCommand) Run(sourceDir string, request OutRequest) (OutRespons
 
 	bucketName := request.Source.Bucket
 
-	var versionID string
-
+	acl := "private"
 	if request.Params.Acl != "" {
-		versionID, err = command.s3client.UploadFileWithAcl(
-			bucketName,
-			remotePath,
-			localPath,
-			request.Params.Acl,
-		)
-	} else {
-		versionID, err = command.s3client.UploadFile(
-			bucketName,
-			remotePath,
-			localPath,
-		)
+		acl = request.Params.Acl
 	}
+
+	versionID, err := command.s3client.UploadFileWithAcl(
+		bucketName,
+		remotePath,
+		localPath,
+		acl,
+	)
 
 	if err != nil {
 		return OutResponse{}, err

--- a/out/out_command.go
+++ b/out/out_command.go
@@ -54,11 +54,24 @@ func (command *OutCommand) Run(sourceDir string, request OutRequest) (OutRespons
 	remotePath := command.remotePath(request, localPath, sourceDir)
 
 	bucketName := request.Source.Bucket
-	versionID, err := command.s3client.UploadFile(
-		bucketName,
-		remotePath,
-		localPath,
-	)
+
+	var versionID string
+
+	if request.Params.Acl != "" {
+		versionID, err = command.s3client.UploadFileWithAcl(
+			bucketName,
+			remotePath,
+			localPath,
+			request.Params.Acl,
+		)
+	} else {
+		versionID, err = command.s3client.UploadFile(
+			bucketName,
+			remotePath,
+			localPath,
+		)
+	}
+
 	if err != nil {
 		return OutResponse{}, err
 	}

--- a/out/out_command_test.go
+++ b/out/out_command_test.go
@@ -139,6 +139,22 @@ var _ = Describe("Out Command", func() {
 				Ω(err).Should(HaveOccurred())
 			})
 
+			It("defaults the acl to 'private'", func() {
+				request.Params.File = "a/*.tgz"
+				createFile("a/file.tgz")
+
+				_, err := command.Run(sourceDir, request)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Ω(s3client.UploadFileWithAclCallCount()).Should(Equal(1))
+				bucketName, remotePath, localPath, acl := s3client.UploadFileWithAclArgsForCall(0)
+
+				Ω(bucketName).Should(Equal("bucket-name"))
+				Ω(remotePath).Should(Equal("file.tgz"))
+				Ω(localPath).Should(Equal(filepath.Join(sourceDir, "a/file.tgz")))
+				Ω(acl).Should(Equal("private"))
+			})
+
 			Context("when specifying acls for the uploaded file", func() {
 				It("applies the specfied acl", func() {
 					request.Params.File = "a/*.tgz"
@@ -180,8 +196,8 @@ var _ = Describe("Out Command", func() {
 				_, err := command.Run(sourceDir, request)
 				Ω(err).ShouldNot(HaveOccurred())
 
-				Ω(s3client.UploadFileCallCount()).Should(Equal(1))
-				bucketName, remotePath, localPath := s3client.UploadFileArgsForCall(0)
+				Ω(s3client.UploadFileWithAclCallCount()).Should(Equal(1))
+				bucketName, remotePath, localPath, _ := s3client.UploadFileWithAclArgsForCall(0)
 
 				Ω(bucketName).Should(Equal("bucket-name"))
 				Ω(remotePath).Should(Equal("a-folder/file.tgz"))
@@ -196,8 +212,8 @@ var _ = Describe("Out Command", func() {
 				_, err := command.Run(sourceDir, request)
 				Ω(err).ShouldNot(HaveOccurred())
 
-				Ω(s3client.UploadFileCallCount()).Should(Equal(1))
-				bucketName, remotePath, localPath := s3client.UploadFileArgsForCall(0)
+				Ω(s3client.UploadFileWithAclCallCount()).Should(Equal(1))
+				bucketName, remotePath, localPath, _ := s3client.UploadFileWithAclArgsForCall(0)
 
 				Ω(bucketName).Should(Equal("bucket-name"))
 				Ω(remotePath).Should(Equal("file.tgz"))
@@ -212,8 +228,8 @@ var _ = Describe("Out Command", func() {
 				response, err := command.Run(sourceDir, request)
 				Ω(err).ShouldNot(HaveOccurred())
 
-				Ω(s3client.UploadFileCallCount()).Should(Equal(1))
-				bucketName, remotePath, localPath := s3client.UploadFileArgsForCall(0)
+				Ω(s3client.UploadFileWithAclCallCount()).Should(Equal(1))
+				bucketName, remotePath, localPath, _ := s3client.UploadFileWithAclArgsForCall(0)
 
 				Ω(bucketName).Should(Equal("bucket-name"))
 				Ω(remotePath).Should(Equal("folder-123/file.tgz"))
@@ -227,7 +243,7 @@ var _ = Describe("Out Command", func() {
 
 			Context("when using versioned buckets", func() {
 				BeforeEach(func() {
-					s3client.UploadFileReturns("123", nil)
+					s3client.UploadFileWithAclReturns("123", nil)
 				})
 
 				It("renames the local file to match the name of the versioned file", func() {
@@ -242,8 +258,8 @@ var _ = Describe("Out Command", func() {
 
 					Ω(err).ShouldNot(HaveOccurred())
 
-					Ω(s3client.UploadFileCallCount()).Should(Equal(1))
-					bucketName, remotePath, localPath := s3client.UploadFileArgsForCall(0)
+					Ω(s3client.UploadFileWithAclCallCount()).Should(Equal(1))
+					bucketName, remotePath, localPath, _ := s3client.UploadFileWithAclArgsForCall(0)
 
 					Ω(bucketName).Should(Equal("bucket-name"))
 					Ω(remotePath).Should(Equal(remoteFileName))
@@ -265,8 +281,8 @@ var _ = Describe("Out Command", func() {
 					response, err := command.Run(sourceDir, request)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(s3client.UploadFileCallCount()).To(Equal(1))
-					bucketName, remotePath, localPath := s3client.UploadFileArgsForCall(0)
+					Ω(s3client.UploadFileWithAclCallCount()).Should(Equal(1))
+					bucketName, remotePath, localPath, _ := s3client.UploadFileWithAclArgsForCall(0)
 					Expect(bucketName).To(Equal("bucket-name"))
 					Expect(remotePath).To(Equal("a-folder/special-file.tgz"))
 					Expect(localPath).To(Equal(filepath.Join(sourceDir, "my/special-file.tgz")))

--- a/out/out_command_test.go
+++ b/out/out_command_test.go
@@ -138,6 +138,25 @@ var _ = Describe("Out Command", func() {
 				_, err := command.Run(sourceDir, request)
 				Ω(err).Should(HaveOccurred())
 			})
+
+			Context("when specifying acls for the uploaded file", func() {
+				It("applies the specfied acl", func() {
+					request.Params.File = "a/*.tgz"
+					request.Params.Acl = "public-read"
+					createFile("a/file.tgz")
+
+					_, err := command.Run(sourceDir, request)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					Ω(s3client.UploadFileWithAclCallCount()).Should(Equal(1))
+					bucketName, remotePath, localPath, acl := s3client.UploadFileWithAclArgsForCall(0)
+
+					Ω(bucketName).Should(Equal("bucket-name"))
+					Ω(remotePath).Should(Equal("file.tgz"))
+					Ω(localPath).Should(Equal(filepath.Join(sourceDir, "a/file.tgz")))
+					Ω(acl).Should(Equal("public-read"))
+				})
+			})
 		})
 
 		Describe("uploading the file with To param", func() {

--- a/s3client.go
+++ b/s3client.go
@@ -44,11 +44,25 @@ type s3client struct {
 
 func NewS3Client(
 	progressOutput io.Writer,
+	awsConfig *aws.Config,
+) (S3Client, error) {
+	sess := session.New(awsConfig)
+	client := s3.New(sess, awsConfig)
+
+	return &s3client{
+		client:  client,
+		session: sess,
+
+		progressOutput: progressOutput,
+	}, nil
+}
+
+func NewAwsConfig(
 	accessKey string,
 	secretKey string,
 	regionName string,
 	endpoint string,
-) (S3Client, error) {
+) (*aws.Config, error) {
 	var creds *credentials.Credentials
 
 	if accessKey == "" && secretKey == "" {
@@ -73,15 +87,7 @@ func NewS3Client(
 		awsConfig.Endpoint = &endpoint
 	}
 
-	sess := session.New(awsConfig)
-	client := s3.New(sess, awsConfig)
-
-	return &s3client{
-		client:  client,
-		session: sess,
-
-		progressOutput: progressOutput,
-	}, nil
+	return awsConfig, nil
 }
 
 func (client *s3client) BucketFiles(bucketName string, prefixHint string) ([]string, error) {

--- a/s3client.go
+++ b/s3client.go
@@ -131,39 +131,7 @@ func (client *s3client) BucketFileVersions(bucketName string, remotePath string)
 }
 
 func (client *s3client) UploadFile(bucketName string, remotePath string, localPath string) (string, error) {
-	uploader := s3manager.NewUploader(client.session)
-
-	stat, err := os.Stat(localPath)
-	if err != nil {
-		return "", err
-	}
-
-	localFile, err := os.Open(localPath)
-	if err != nil {
-		return "", err
-	}
-
-	defer localFile.Close()
-
-	progress := client.newProgressBar(stat.Size())
-
-	progress.Start()
-	defer progress.Finish()
-
-	uploadOutput, err := uploader.Upload(&s3manager.UploadInput{
-		Bucket: aws.String(bucketName),
-		Key:    aws.String(remotePath),
-		Body:   progress.NewProxyReader(localFile),
-	})
-	if err != nil {
-		return "", err
-	}
-
-	if uploadOutput.VersionID != nil {
-		return *uploadOutput.VersionID, nil
-	}
-
-	return "", nil
+	return client.UploadFileWithAcl(bucketName, remotePath, localPath, "private")
 }
 
 func (client *s3client) UploadFileWithAcl(bucketName string, remotePath string, localPath string, acl string) (string, error) {


### PR DESCRIPTION
* this change will allow you to specify a [canned acl](http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html)
  that will be applied to the uploaded file.

This feature is useful when you want to publish objects and make them public immediately.

**TODO**

* [x] I've only manually inspected `s3` to see if the permissions are correct (by temporarily removing cleanup of the files in the integration tests and looking at the s3 web console). In order to test this I would need to use [`GetObjectAcl`](http://docs.aws.amazon.com/sdk-for-go/api/service/s3/S3.html#GetObjectAcl-instance_method) but could use some guidance on how to do this. I could add a function to `s3client` but I feel that directly using the `aws-sdk` in the integration specs might be better than conflating `s3client` just for testing purposes.
* [x] `UploadFileWithAcl` is pretty much a duplicate of `UploadFile`. An alternative would be to add an `Options` hash as a new param to `UploadFile` and load more logic there. I could use some feedback on how to remove all this duplication.
* [x] The `if` block that was introduced to `out.Run` is very ugly. Perhaps figured out what the default `Acl` is and be explicit about it at all times. Then the `if` block could just be determining what that value needs to be.

Attached is what the **Permissions** should look like (if specifying `acl: public-read`) in the web console:

![permissions](https://cloud.githubusercontent.com/assets/89754/15085889/e9518f1c-1391-11e6-8e72-598bfd6bac9d.png)
