### PR TITLE
Adding S3_ENDPOINT to be pass to the job

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -8,6 +8,7 @@ params:
   S3_TESTING_BUCKET:
   S3_VERSIONED_TESTING_BUCKET:
   S3_TESTING_REGION:
+  S3_ENDPOINT:
 
 inputs:
 - name: s3-resource


### PR DESCRIPTION
Test failed if we don't use standard region, because the endpoint is different.

The test already support custom endpoint, but the env. variable `S3_ENDPOINT` is not pass to the one-off task "build.yml"

Just adding the possibility to pass it. 


```bash
Expected
      <in.InResponse>: {
          Version: {
              Path: "",
              VersionID: "ooPCrMNmcfmoUCBVrE8HbTUDLfaU4ErS",
          },
          Metadata: [
              {Name: "filename", Value: "some-file"},
              {
                  Name: "url",
                  Value: "https://s3-ap-northeast-1.amazonaws.com/XXXX-gwenn-dedicated-version/in-request-files-versioned/some-file?versionId=ooPCrMNmcfmoUCBVrE8HbTUDLfaU4ErS",
              },
          ],
      }
  to equal
      <in.InResponse>: {
          Version: {
              Path: "",
              VersionID: "ooPCrMNmcfmoUCBVrE8HbTUDLfaU4ErS",
          },
          Metadata: [
              {Name: "filename", Value: "some-file"},
              {
                  Name: "url",
                  Value: "https://s3.amazonaws.com/XXXX-dedicated-version/in-request-files-versioned/some-file?versionId=ooPCrMNmcfmoUCBVrE8HbTUDLfaU4ErS",
              },
          ],
      }



```