### PR TITLE
Add disableSSL for s3 compatible providers without SSL endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ version numbers.
 
 * `endpoint`: *Optional.* Custom endpoint for using S3 compatible provider.
 
-* `disableSSL`: *Optional.* Disable SSL for the endpoint, useful for S3 compatible providers without SSL.
+* `disable_ssl`: *Optional.* Disable SSL for the endpoint, useful for S3 compatible providers without SSL.
 
 ### File Names
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ version numbers.
 
 * `endpoint`: *Optional.* Custom endpoint for using S3 compatible provider.
 
+* `disableSSL`: *Optional.* Disable SSL for the endpoint, useful for S3 compatible providers without SSL.
+
 ### File Names
 
 One of the following two options must be specified:

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -17,6 +17,7 @@ func main() {
 		request.Source.SecretAccessKey,
 		request.Source.RegionName,
 		request.Source.Endpoint,
+		request.Source.DisableSSL,
 	)
 
 	client := s3resource.NewS3Client(

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -24,6 +24,7 @@ func main() {
 		request.Source.SecretAccessKey,
 		request.Source.RegionName,
 		request.Source.Endpoint,
+		request.Source.DisableSSL,
 	)
 
 	client := s3resource.NewS3Client(

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -24,6 +24,7 @@ func main() {
 		request.Source.SecretAccessKey,
 		request.Source.RegionName,
 		request.Source.Endpoint,
+		request.Source.DisableSSL,
 	)
 
 	client := s3resource.NewS3Client(

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -75,6 +75,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		secretAccessKey,
 		regionName,
 		endpoint,
+		false,
 	)
 
 	s3Service = s3.New(session.New(awsConfig), awsConfig)

--- a/models.go
+++ b/models.go
@@ -10,6 +10,7 @@ type Source struct {
 	RegionName      string `json:"region_name"`
 	CloudfrontURL   string `json:"cloudfront_url"`
 	Endpoint        string `json:"endpoint"`
+	DisableSSL      bool   `json:"disableSSL"`
 }
 
 func (source Source) IsValid() (bool, string) {

--- a/models.go
+++ b/models.go
@@ -10,7 +10,7 @@ type Source struct {
 	RegionName      string `json:"region_name"`
 	CloudfrontURL   string `json:"cloudfront_url"`
 	Endpoint        string `json:"endpoint"`
-	DisableSSL      bool   `json:"disableSSL"`
+	DisableSSL      bool   `json:"disable_ssl"`
 }
 
 func (source Source) IsValid() (bool, string) {

--- a/s3client.go
+++ b/s3client.go
@@ -61,6 +61,7 @@ func NewAwsConfig(
 	secretKey string,
 	regionName string,
 	endpoint string,
+	disableSSL bool,
 ) *aws.Config {
 	var creds *credentials.Credentials
 
@@ -79,6 +80,7 @@ func NewAwsConfig(
 		Credentials:      creds,
 		S3ForcePathStyle: aws.Bool(true),
 		MaxRetries:       aws.Int(maxRetries),
+		DisableSSL:       aws.Bool(disableSSL),
 	}
 
 	if len(endpoint) != 0 {


### PR DESCRIPTION
Minio doesn't provide a HTTPS endpoint. This is also not required when running everything on-site. Therefor disabling SSL (already provided by the AWS sdk) is an easy solution.