### PR TITLE
Accept encryption options from source.

### DIFF
--- a/fakes/fake_s3client.go
+++ b/fakes/fake_s3client.go
@@ -28,13 +28,15 @@ type FakeS3Client struct {
 		result1 []string
 		result2 error
 	}
-	UploadFileStub        func(bucketName string, remotePath string, localPath string, acl string) (string, error)
+	UploadFileStub        func(bucketName string, remotePath string, localPath string, acl string, serverSideEncryption string, kmsKeyId string) (string, error)
 	uploadFileMutex       sync.RWMutex
 	uploadFileArgsForCall []struct {
-		bucketName string
-		remotePath string
-		localPath  string
-		acl        string
+		bucketName           string
+		remotePath           string
+		localPath            string
+		acl                  string
+		serverSideEncryption string
+		kmsKeyId             string
 	}
 	uploadFileReturns struct {
 		result1 string
@@ -151,17 +153,19 @@ func (fake *FakeS3Client) BucketFileVersionsReturns(result1 []string, result2 er
 	}{result1, result2}
 }
 
-func (fake *FakeS3Client) UploadFile(bucketName string, remotePath string, localPath string, acl string) (string, error) {
+func (fake *FakeS3Client) UploadFile(bucketName string, remotePath string, localPath string, acl string, serverSideEncryption string, kmsKeyId string) (string, error) {
 	fake.uploadFileMutex.Lock()
 	fake.uploadFileArgsForCall = append(fake.uploadFileArgsForCall, struct {
-		bucketName string
-		remotePath string
-		localPath  string
-		acl        string
-	}{bucketName, remotePath, localPath, acl})
+		bucketName           string
+		remotePath           string
+		localPath            string
+		acl                  string
+		serverSideEncryption string
+		kmsKeyId             string
+	}{bucketName, remotePath, localPath, acl, serverSideEncryption, kmsKeyId})
 	fake.uploadFileMutex.Unlock()
 	if fake.UploadFileStub != nil {
-		return fake.UploadFileStub(bucketName, remotePath, localPath, acl)
+		return fake.UploadFileStub(bucketName, remotePath, localPath, acl, serverSideEncryption, kmsKeyId)
 	} else {
 		return fake.uploadFileReturns.result1, fake.uploadFileReturns.result2
 	}

--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -99,7 +99,7 @@ var _ = Describe("check", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					tempFile.Close()
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-not-match-1"), tempFile.Name(), "private")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-not-match-1"), tempFile.Name(), "private", "", "")
 					Ω(err).ShouldNot(HaveOccurred())
 
 					err = os.Remove(tempFile.Name())
@@ -133,10 +133,10 @@ var _ = Describe("check", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					tempFile.Close()
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-2"), tempFile.Name(), "private")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-2"), tempFile.Name(), "private", "", "")
 					Ω(err).ShouldNot(HaveOccurred())
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-1"), tempFile.Name(), "private")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-1"), tempFile.Name(), "private", "", "")
 					Ω(err).ShouldNot(HaveOccurred())
 
 					err = os.Remove(tempFile.Name())
@@ -194,7 +194,7 @@ var _ = Describe("check", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					tempFile.Close()
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private", "", "")
 					Ω(err).ShouldNot(HaveOccurred())
 
 					err = os.Remove(tempFile.Name())
@@ -223,7 +223,7 @@ var _ = Describe("check", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					tempFile.Close()
 
-					_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "file-does-not-match"), tempFile.Name(), "private")
+					_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "file-does-not-match"), tempFile.Name(), "private", "", "")
 					Ω(err).ShouldNot(HaveOccurred())
 
 					err = os.Remove(tempFile.Name())
@@ -263,10 +263,10 @@ var _ = Describe("check", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					tempFile.Close()
 
-					_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private")
+					_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private", "", "")
 					Ω(err).ShouldNot(HaveOccurred())
 
-					_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private")
+					_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private", "", "")
 					Ω(err).ShouldNot(HaveOccurred())
 
 					err = os.Remove(tempFile.Name())
@@ -333,7 +333,7 @@ var _ = Describe("check", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					tempFile.Close()
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-not-match-1"), tempFile.Name(), "private")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-not-match-1"), tempFile.Name(), "private", "", "")
 					Ω(err).ShouldNot(HaveOccurred())
 
 					err = os.Remove(tempFile.Name())
@@ -368,13 +368,13 @@ var _ = Describe("check", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					tempFile.Close()
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-2"), tempFile.Name(), "private")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-2"), tempFile.Name(), "private", "", "")
 					Ω(err).ShouldNot(HaveOccurred())
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-1"), tempFile.Name(), "private")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-1"), tempFile.Name(), "private", "", "")
 					Ω(err).ShouldNot(HaveOccurred())
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-3"), tempFile.Name(), "private")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-3"), tempFile.Name(), "private", "", "")
 					Ω(err).ShouldNot(HaveOccurred())
 
 					err = os.Remove(tempFile.Name())
@@ -422,16 +422,16 @@ var _ = Describe("check", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					tempFile.Close()
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-1.2.0-rc.2"), tempFile.Name(), "private")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-1.2.0-rc.2"), tempFile.Name(), "private", "", "")
 					Ω(err).ShouldNot(HaveOccurred())
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-1.2.0-rc.1"), tempFile.Name(), "private")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-1.2.0-rc.1"), tempFile.Name(), "private", "", "")
 					Ω(err).ShouldNot(HaveOccurred())
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-1.1.0-rc.1"), tempFile.Name(), "private")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-1.1.0-rc.1"), tempFile.Name(), "private", "", "")
 					Ω(err).ShouldNot(HaveOccurred())
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-1.1.0-rc.2"), tempFile.Name(), "private")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-1.1.0-rc.2"), tempFile.Name(), "private", "", "")
 					Ω(err).ShouldNot(HaveOccurred())
 
 					err = os.Remove(tempFile.Name())
@@ -489,7 +489,7 @@ var _ = Describe("check", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					tempFile.Close()
 
-					_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "file-does-not-match"), tempFile.Name(), "private")
+					_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "file-does-not-match"), tempFile.Name(), "private", "", "")
 					Ω(err).ShouldNot(HaveOccurred())
 
 					err = os.Remove(tempFile.Name())
@@ -535,13 +535,13 @@ var _ = Describe("check", func() {
 						Ω(err).ShouldNot(HaveOccurred())
 						tempFile.Close()
 
-						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private")
+						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private", "", "")
 						Ω(err).ShouldNot(HaveOccurred())
 
-						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private")
+						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private", "", "")
 						Ω(err).ShouldNot(HaveOccurred())
 
-						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private")
+						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private", "", "")
 						Ω(err).ShouldNot(HaveOccurred())
 
 						checkRequest.Source.VersionedFile = filepath.Join(directoryPrefix, "versioned-file")
@@ -598,13 +598,13 @@ var _ = Describe("check", func() {
 						Ω(err).ShouldNot(HaveOccurred())
 						tempFile.Close()
 
-						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private")
+						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private", "", "")
 						Ω(err).ShouldNot(HaveOccurred())
 
-						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private")
+						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private", "", "")
 						Ω(err).ShouldNot(HaveOccurred())
 
-						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private")
+						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private", "", "")
 						Ω(err).ShouldNot(HaveOccurred())
 
 						checkRequest.Source.VersionedFile = filepath.Join(directoryPrefix, "versioned-file")

--- a/integration/in_test.go
+++ b/integration/in_test.go
@@ -109,19 +109,19 @@ var _ = Describe("in", func() {
 			err = ioutil.WriteFile(tempFile.Name(), []byte("some-file-1"), 0755)
 			Ω(err).ShouldNot(HaveOccurred())
 
-			_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "some-file-1"), tempFile.Name(), "private")
+			_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "some-file-1"), tempFile.Name(), "private", "", "")
 			Ω(err).ShouldNot(HaveOccurred())
 
 			err = ioutil.WriteFile(tempFile.Name(), []byte("some-file-2"), 0755)
 			Ω(err).ShouldNot(HaveOccurred())
 
-			_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "some-file-2"), tempFile.Name(), "private")
+			_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "some-file-2"), tempFile.Name(), "private", "", "")
 			Ω(err).ShouldNot(HaveOccurred())
 
 			err = ioutil.WriteFile(tempFile.Name(), []byte("some-file-3"), 0755)
 			Ω(err).ShouldNot(HaveOccurred())
 
-			_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "some-file-3"), tempFile.Name(), "private")
+			_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "some-file-3"), tempFile.Name(), "private", "", "")
 			Ω(err).ShouldNot(HaveOccurred())
 
 			err = os.Remove(tempFile.Name())
@@ -204,19 +204,19 @@ var _ = Describe("in", func() {
 			err = ioutil.WriteFile(tempFile.Name(), []byte("some-file-1"), 0755)
 			Ω(err).ShouldNot(HaveOccurred())
 
-			_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "some-file"), tempFile.Name(), "private")
+			_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "some-file"), tempFile.Name(), "private", "", "")
 			Ω(err).ShouldNot(HaveOccurred())
 
 			err = ioutil.WriteFile(tempFile.Name(), []byte("some-file-2"), 0755)
 			Ω(err).ShouldNot(HaveOccurred())
 
-			_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "some-file"), tempFile.Name(), "private")
+			_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "some-file"), tempFile.Name(), "private", "", "")
 			Ω(err).ShouldNot(HaveOccurred())
 
 			err = ioutil.WriteFile(tempFile.Name(), []byte("some-file-3"), 0755)
 			Ω(err).ShouldNot(HaveOccurred())
 
-			_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "some-file"), tempFile.Name(), "private")
+			_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "some-file"), tempFile.Name(), "private", "", "")
 			Ω(err).ShouldNot(HaveOccurred())
 
 			versions, err := s3client.BucketFileVersions(versionedBucketName, filepath.Join(directoryPrefix, "some-file"))

--- a/models.go
+++ b/models.go
@@ -1,16 +1,18 @@
 package s3resource
 
 type Source struct {
-	AccessKeyID     string `json:"access_key_id"`
-	SecretAccessKey string `json:"secret_access_key"`
-	Bucket          string `json:"bucket"`
-	Regexp          string `json:"regexp"`
-	VersionedFile   string `json:"versioned_file"`
-	Private         bool   `json:"private"`
-	RegionName      string `json:"region_name"`
-	CloudfrontURL   string `json:"cloudfront_url"`
-	Endpoint        string `json:"endpoint"`
-	DisableSSL      bool   `json:"disable_ssl"`
+	AccessKeyID          string `json:"access_key_id"`
+	SecretAccessKey      string `json:"secret_access_key"`
+	Bucket               string `json:"bucket"`
+	Regexp               string `json:"regexp"`
+	VersionedFile        string `json:"versioned_file"`
+	Private              bool   `json:"private"`
+	RegionName           string `json:"region_name"`
+	CloudfrontURL        string `json:"cloudfront_url"`
+	Endpoint             string `json:"endpoint"`
+	DisableSSL           bool   `json:"disable_ssl"`
+	ServerSideEncryption string `json:"server_side_encryption"`
+	SSEKMSKeyId          string `json:"sse_kms_key_id"`
 }
 
 func (source Source) IsValid() (bool, string) {

--- a/out/out_command.go
+++ b/out/out_command.go
@@ -65,6 +65,8 @@ func (command *OutCommand) Run(sourceDir string, request OutRequest) (OutRespons
 		remotePath,
 		localPath,
 		acl,
+		request.Source.ServerSideEncryption,
+		request.Source.SSEKMSKeyId,
 	)
 	if err != nil {
 		return OutResponse{}, err

--- a/s3client.go
+++ b/s3client.go
@@ -21,7 +21,7 @@ type S3Client interface {
 	BucketFiles(bucketName string, prefixHint string) ([]string, error)
 	BucketFileVersions(bucketName string, remotePath string) ([]string, error)
 
-	UploadFile(bucketName string, remotePath string, localPath string, acl string) (string, error)
+	UploadFile(bucketName string, remotePath string, localPath string, acl string, serverSideEncryption string, kmsKeyId string) (string, error)
 	DownloadFile(bucketName string, remotePath string, versionID string, localPath string) error
 
 	DeleteFile(bucketName string, remotePath string) error
@@ -131,7 +131,7 @@ func (client *s3client) BucketFileVersions(bucketName string, remotePath string)
 	return versions, nil
 }
 
-func (client *s3client) UploadFile(bucketName string, remotePath string, localPath string, acl string) (string, error) {
+func (client *s3client) UploadFile(bucketName string, remotePath string, localPath string, acl string, serverSideEncryption string, kmsKeyId string) (string, error) {
 	uploader := s3manager.NewUploader(client.session)
 
 	stat, err := os.Stat(localPath)
@@ -151,12 +151,20 @@ func (client *s3client) UploadFile(bucketName string, remotePath string, localPa
 	progress.Start()
 	defer progress.Finish()
 
-	uploadOutput, err := uploader.Upload(&s3manager.UploadInput{
+	uploadInput := s3manager.UploadInput{
 		Bucket: aws.String(bucketName),
 		Key:    aws.String(remotePath),
 		Body:   progressSeekReaderAt{localFile, progress},
 		ACL:    aws.String(acl),
-	})
+	}
+	if serverSideEncryption != "" {
+		uploadInput.ServerSideEncryption = aws.String(serverSideEncryption)
+	}
+	if kmsKeyId != "" {
+		uploadInput.SSEKMSKeyId = aws.String(kmsKeyId)
+	}
+
+	uploadOutput, err := uploader.Upload(&uploadInput)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Helpful for users who have to use encryption for compliance purposes,
such as cloud.gov.