### PR TITLE
Add `virtual_hosted_style` flag to allow interactions with CloudFront

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,12 @@ version numbers.
   URLs provided are signed.
 
 * `cloudfront_url`: *Optional.* The URL (scheme and domain) of your CloudFront
-  distribution that is fronting this bucket. This will be used in the `url`
-  file that is given to the following task.
+  distribution that is fronting this bucket (e.g
+  `https://d5yxxxxx.cloudfront.net`).  This will affect `in` but not `check`
+  and `put`. `in` will ignore the `bucket` name setting, exclusively using the
+  `cloudfront_url`.  When configuring CloudFront with versioned buckets, set
+  `Query String Forwarding and Caching` to `Forward all, cache based on all` to
+  ensure S3 calls succeed.
 
 * `endpoint`: *Optional.* Custom endpoint for using S3 compatible provider.
 
@@ -33,6 +37,7 @@ version numbers.
 
 * `sse_kms_key_id`: *Optional.* The ID of the AWS KMS master encryption key
   used for the object.
+
 
 ### File Names
 

--- a/in/in_command.go
+++ b/in/in_command.go
@@ -8,7 +8,6 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/cloudfoundry/gunk/urljoiner"
 	"github.com/concourse/s3-resource"
 	"github.com/concourse/s3-resource/versions"
 )
@@ -20,25 +19,11 @@ type RequestURLProvider struct {
 }
 
 func (up *RequestURLProvider) GetURL(request InRequest, remotePath string) string {
-	if request.Source.CloudfrontURL != "" {
-		return up.cloudfrontURL(request, remotePath)
-	}
-
 	return up.s3URL(request, remotePath)
 }
 
 func (up *RequestURLProvider) s3URL(request InRequest, remotePath string) string {
 	return up.s3Client.URL(request.Source.Bucket, remotePath, request.Source.Private, request.Version.VersionID)
-}
-
-func (up *RequestURLProvider) cloudfrontURL(request InRequest, remotePath string) string {
-	url := urljoiner.Join(request.Source.CloudfrontURL, remotePath)
-
-	if request.Version.VersionID != "" {
-		url = url + "?versionId=" + request.Version.VersionID
-	}
-
-	return url
 }
 
 type InCommand struct {

--- a/in/in_command_test.go
+++ b/in/in_command_test.go
@@ -109,25 +109,6 @@ var _ = Describe("In Command", func() {
 				Ω(versionID).Should(BeEmpty())
 			})
 
-			Context("when using a CloudFront domain", func() {
-				BeforeEach(func() {
-					request.Source.CloudfrontURL = "https://1234567890.cloudfront.net"
-				})
-
-				It("creates a 'url' file that contains the URL including the CloudFront domain", func() {
-					urlPath := filepath.Join(destDir, "url")
-					Ω(urlPath).ShouldNot(ExistOnFilesystem())
-
-					_, err := command.Run(destDir, request)
-					Ω(err).ShouldNot(HaveOccurred())
-
-					Ω(urlPath).Should(ExistOnFilesystem())
-					contents, err := ioutil.ReadFile(urlPath)
-					Ω(err).ShouldNot(HaveOccurred())
-					Ω(string(contents)).Should(Equal("https://1234567890.cloudfront.net/files/a-file-1.3.tgz"))
-				})
-			})
-
 			Context("when configured with private URLs", func() {
 				BeforeEach(func() {
 					request.Source.Private = true

--- a/integration/out_test.go
+++ b/integration/out_test.go
@@ -286,7 +286,6 @@ var _ = Describe("out", func() {
 				Ω(session.Err).Should(gbytes.Say("object versioning not enabled"))
 			})
 		})
-
 	})
 
 	Context("with a versioned bucket", func() {

--- a/s3client.go
+++ b/s3client.go
@@ -288,6 +288,7 @@ func (client *s3client) getBucketContents(bucketName string, prefix string) (map
 		}
 
 		if *listObjectsResponse.IsTruncated {
+			prevMarker := marker
 			if listObjectsResponse.NextMarker == nil {
 				// From the s3 docs: If response does not include the
 				// NextMarker and it is truncated, you can use the value of the
@@ -296,6 +297,9 @@ func (client *s3client) getBucketContents(bucketName string, prefix string) (map
 				marker = lastKey
 			} else {
 				marker = *listObjectsResponse.NextMarker
+			}
+			if marker == prevMarker {
+				return nil, errors.New("Unable to list all bucket objects; perhaps this is a CloudFront S3 bucket that needs its `Query String Forwarding and Caching` set to `Forward all, cache based on all`?")
 			}
 		} else {
 			break


### PR DESCRIPTION
- the core functionality is that it allows the bucket name
  to be prepended to the hostname (e.g. `dulfnruy35dwq.cloudfront.net`)
  instead of default to the path (e.g. `cloudfront.net/dulfnruy35dwq`)
- particularly effective when downloading assets from an
  unstable network (i.e. AWS China)
- this should not be confused with the `cloudfront_url` flag,
  which modifies the URL being outputted but does not affect
  the URL used to check/in/out.

```yaml
source:
  bucket: dulfnruy35dwq
  endpoint: cloudfront.net
  force_path_style: false
```

Signed-off-by: Brian Cunnie <bcunnie@pivotal.io>

[#129581055](https://www.pivotaltracker.com/story/show/129581055)