### PR TITLE
Check S3_ENDPOINT before integration test run

### DIFF
--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -70,6 +70,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Ω(versionedBucketName).ShouldNot(BeEmpty(), "must specify $S3_VERSIONED_TESTING_BUCKET")
 	Ω(bucketName).ShouldNot(BeEmpty(), "must specify $S3_TESTING_BUCKET")
 	Ω(regionName).ShouldNot(BeEmpty(), "must specify $S3_TESTING_REGION")
+	Ω(endpoint).ShouldNot(BeEmpty(), "must specify $S3_ENDPOINT")
 
 	awsConfig := s3resource.NewAwsConfig(
 		accessKeyID,


### PR DESCRIPTION
Are there any test suites that rely on the behavior of $S3_ENDPOINT defaulting to `https://s3.amazonaws.com` if it's not set?

When running the tests locally, if this variable is not set, you get a
test failure that's very tricky to spot. This should highlight it.

If $S3_ENDPOINT is unset/empty, you get:

```
  Expected
      <in.InResponse>: {
          Version: {
              Path: "",
              VersionID: "yMOjcgIH.ioLfj2FTOGQshUrqnkI00_o",
          },
          Metadata: [
              {Name: "filename", Value: "some-file"},
              {
                  Name: "url",
                  Value: "https://s3-us-west-2.amazonaws.com/s3-resource-ginkgo-test-bucket-versioned/in-request-files-versioned/some-file?versionId=yMOjcgIH.ioLfj2FTOGQshUrqnkI00_o",
              },
          ],
      }
  to equal
      <in.InResponse>: {
          Version: {
              Path: "",
              VersionID: "yMOjcgIH.ioLfj2FTOGQshUrqnkI00_o",
          },
          Metadata: [
              {Name: "filename", Value: "some-file"},
              {
                  Name: "url",
                  Value: "https://s3.amazonaws.com/s3-resource-ginkgo-test-bucket-versioned/in-request-files-versioned/some-file?versionId=yMOjcgIH.ioLfj2FTOGQshUrqnkI00_o",
              },
          ],
      }
```

But with this change, you'll instead see:

```
  must specify $S3_ENDPOINT
  Expected
      <string>:
  not to be empty
```
