### PR TITLE
Added the option to set the content-type metadata when uploading a file

### DIFF
--- a/fakes/fake_s3client.go
+++ b/fakes/fake_s3client.go
@@ -4,7 +4,7 @@ package fakes
 import (
 	"sync"
 
-	"github.com/concourse/s3-resource"
+	s3resource "github.com/concourse/s3-resource"
 )
 
 type FakeS3Client struct {
@@ -28,15 +28,13 @@ type FakeS3Client struct {
 		result1 []string
 		result2 error
 	}
-	UploadFileStub        func(bucketName string, remotePath string, localPath string, acl string, serverSideEncryption string, kmsKeyId string) (string, error)
+	UploadFileStub        func(bucketName string, remotePath string, localPath string, options s3resource.UploadFileOptions) (string, error)
 	uploadFileMutex       sync.RWMutex
 	uploadFileArgsForCall []struct {
-		bucketName           string
-		remotePath           string
-		localPath            string
-		acl                  string
-		serverSideEncryption string
-		kmsKeyId             string
+		bucketName string
+		remotePath string
+		localPath  string
+		options    s3resource.UploadFileOptions
 	}
 	uploadFileReturns struct {
 		result1 string
@@ -83,6 +81,8 @@ type FakeS3Client struct {
 	uRLReturns struct {
 		result1 string
 	}
+	invocations      map[string][][]interface{}
+	invocationsMutex sync.RWMutex
 }
 
 func (fake *FakeS3Client) BucketFiles(bucketName string, prefixHint string) ([]string, error) {
@@ -91,6 +91,7 @@ func (fake *FakeS3Client) BucketFiles(bucketName string, prefixHint string) ([]s
 		bucketName string
 		prefixHint string
 	}{bucketName, prefixHint})
+	fake.recordInvocation("BucketFiles", []interface{}{bucketName, prefixHint})
 	fake.bucketFilesMutex.Unlock()
 	if fake.BucketFilesStub != nil {
 		return fake.BucketFilesStub(bucketName, prefixHint)
@@ -125,6 +126,7 @@ func (fake *FakeS3Client) BucketFileVersions(bucketName string, remotePath strin
 		bucketName string
 		remotePath string
 	}{bucketName, remotePath})
+	fake.recordInvocation("BucketFileVersions", []interface{}{bucketName, remotePath})
 	fake.bucketFileVersionsMutex.Unlock()
 	if fake.BucketFileVersionsStub != nil {
 		return fake.BucketFileVersionsStub(bucketName, remotePath)
@@ -153,19 +155,18 @@ func (fake *FakeS3Client) BucketFileVersionsReturns(result1 []string, result2 er
 	}{result1, result2}
 }
 
-func (fake *FakeS3Client) UploadFile(bucketName string, remotePath string, localPath string, acl string, serverSideEncryption string, kmsKeyId string) (string, error) {
+func (fake *FakeS3Client) UploadFile(bucketName string, remotePath string, localPath string, options s3resource.UploadFileOptions) (string, error) {
 	fake.uploadFileMutex.Lock()
 	fake.uploadFileArgsForCall = append(fake.uploadFileArgsForCall, struct {
-		bucketName           string
-		remotePath           string
-		localPath            string
-		acl                  string
-		serverSideEncryption string
-		kmsKeyId             string
-	}{bucketName, remotePath, localPath, acl, serverSideEncryption, kmsKeyId})
+		bucketName string
+		remotePath string
+		localPath  string
+		options    s3resource.UploadFileOptions
+	}{bucketName, remotePath, localPath, options})
+	fake.recordInvocation("UploadFile", []interface{}{bucketName, remotePath, localPath, options})
 	fake.uploadFileMutex.Unlock()
 	if fake.UploadFileStub != nil {
-		return fake.UploadFileStub(bucketName, remotePath, localPath, acl, serverSideEncryption, kmsKeyId)
+		return fake.UploadFileStub(bucketName, remotePath, localPath, options)
 	} else {
 		return fake.uploadFileReturns.result1, fake.uploadFileReturns.result2
 	}
@@ -177,10 +178,10 @@ func (fake *FakeS3Client) UploadFileCallCount() int {
 	return len(fake.uploadFileArgsForCall)
 }
 
-func (fake *FakeS3Client) UploadFileArgsForCall(i int) (string, string, string, string) {
+func (fake *FakeS3Client) UploadFileArgsForCall(i int) (string, string, string, s3resource.UploadFileOptions) {
 	fake.uploadFileMutex.RLock()
 	defer fake.uploadFileMutex.RUnlock()
-	return fake.uploadFileArgsForCall[i].bucketName, fake.uploadFileArgsForCall[i].remotePath, fake.uploadFileArgsForCall[i].localPath, fake.uploadFileArgsForCall[i].acl
+	return fake.uploadFileArgsForCall[i].bucketName, fake.uploadFileArgsForCall[i].remotePath, fake.uploadFileArgsForCall[i].localPath, fake.uploadFileArgsForCall[i].options
 }
 
 func (fake *FakeS3Client) UploadFileReturns(result1 string, result2 error) {
@@ -199,6 +200,7 @@ func (fake *FakeS3Client) DownloadFile(bucketName string, remotePath string, ver
 		versionID  string
 		localPath  string
 	}{bucketName, remotePath, versionID, localPath})
+	fake.recordInvocation("DownloadFile", []interface{}{bucketName, remotePath, versionID, localPath})
 	fake.downloadFileMutex.Unlock()
 	if fake.DownloadFileStub != nil {
 		return fake.DownloadFileStub(bucketName, remotePath, versionID, localPath)
@@ -232,6 +234,7 @@ func (fake *FakeS3Client) DeleteFile(bucketName string, remotePath string) error
 		bucketName string
 		remotePath string
 	}{bucketName, remotePath})
+	fake.recordInvocation("DeleteFile", []interface{}{bucketName, remotePath})
 	fake.deleteFileMutex.Unlock()
 	if fake.DeleteFileStub != nil {
 		return fake.DeleteFileStub(bucketName, remotePath)
@@ -266,6 +269,7 @@ func (fake *FakeS3Client) DeleteVersionedFile(bucketName string, remotePath stri
 		remotePath string
 		versionID  string
 	}{bucketName, remotePath, versionID})
+	fake.recordInvocation("DeleteVersionedFile", []interface{}{bucketName, remotePath, versionID})
 	fake.deleteVersionedFileMutex.Unlock()
 	if fake.DeleteVersionedFileStub != nil {
 		return fake.DeleteVersionedFileStub(bucketName, remotePath, versionID)
@@ -301,6 +305,7 @@ func (fake *FakeS3Client) URL(bucketName string, remotePath string, private bool
 		private    bool
 		versionID  string
 	}{bucketName, remotePath, private, versionID})
+	fake.recordInvocation("URL", []interface{}{bucketName, remotePath, private, versionID})
 	fake.uRLMutex.Unlock()
 	if fake.URLStub != nil {
 		return fake.URLStub(bucketName, remotePath, private, versionID)
@@ -326,6 +331,38 @@ func (fake *FakeS3Client) URLReturns(result1 string) {
 	fake.uRLReturns = struct {
 		result1 string
 	}{result1}
+}
+
+func (fake *FakeS3Client) Invocations() map[string][][]interface{} {
+	fake.invocationsMutex.RLock()
+	defer fake.invocationsMutex.RUnlock()
+	fake.bucketFilesMutex.RLock()
+	defer fake.bucketFilesMutex.RUnlock()
+	fake.bucketFileVersionsMutex.RLock()
+	defer fake.bucketFileVersionsMutex.RUnlock()
+	fake.uploadFileMutex.RLock()
+	defer fake.uploadFileMutex.RUnlock()
+	fake.downloadFileMutex.RLock()
+	defer fake.downloadFileMutex.RUnlock()
+	fake.deleteFileMutex.RLock()
+	defer fake.deleteFileMutex.RUnlock()
+	fake.deleteVersionedFileMutex.RLock()
+	defer fake.deleteVersionedFileMutex.RUnlock()
+	fake.uRLMutex.RLock()
+	defer fake.uRLMutex.RUnlock()
+	return fake.invocations
+}
+
+func (fake *FakeS3Client) recordInvocation(key string, args []interface{}) {
+	fake.invocationsMutex.Lock()
+	defer fake.invocationsMutex.Unlock()
+	if fake.invocations == nil {
+		fake.invocations = map[string][][]interface{}{}
+	}
+	if fake.invocations[key] == nil {
+		fake.invocations[key] = [][]interface{}{}
+	}
+	fake.invocations[key] = append(fake.invocations[key], args)
 }
 
 var _ s3resource.S3Client = new(FakeS3Client)

--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -99,7 +99,7 @@ var _ = Describe("check", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					tempFile.Close()
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-not-match-1"), tempFile.Name(), "private", "", "")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-not-match-1"), tempFile.Name(), s3resource.NewUploadFileOptions())
 					Ω(err).ShouldNot(HaveOccurred())
 
 					err = os.Remove(tempFile.Name())
@@ -133,10 +133,10 @@ var _ = Describe("check", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					tempFile.Close()
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-2"), tempFile.Name(), "private", "", "")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-2"), tempFile.Name(), s3resource.NewUploadFileOptions())
 					Ω(err).ShouldNot(HaveOccurred())
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-1"), tempFile.Name(), "private", "", "")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-1"), tempFile.Name(), s3resource.NewUploadFileOptions())
 					Ω(err).ShouldNot(HaveOccurred())
 
 					err = os.Remove(tempFile.Name())
@@ -194,7 +194,7 @@ var _ = Describe("check", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					tempFile.Close()
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private", "", "")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), s3resource.NewUploadFileOptions())
 					Ω(err).ShouldNot(HaveOccurred())
 
 					err = os.Remove(tempFile.Name())
@@ -223,7 +223,7 @@ var _ = Describe("check", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					tempFile.Close()
 
-					_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "file-does-not-match"), tempFile.Name(), "private", "", "")
+					_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "file-does-not-match"), tempFile.Name(), s3resource.NewUploadFileOptions())
 					Ω(err).ShouldNot(HaveOccurred())
 
 					err = os.Remove(tempFile.Name())
@@ -263,10 +263,10 @@ var _ = Describe("check", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					tempFile.Close()
 
-					_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private", "", "")
+					_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), s3resource.NewUploadFileOptions())
 					Ω(err).ShouldNot(HaveOccurred())
 
-					_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private", "", "")
+					_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), s3resource.NewUploadFileOptions())
 					Ω(err).ShouldNot(HaveOccurred())
 
 					err = os.Remove(tempFile.Name())
@@ -333,7 +333,7 @@ var _ = Describe("check", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					tempFile.Close()
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-not-match-1"), tempFile.Name(), "private", "", "")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-not-match-1"), tempFile.Name(), s3resource.NewUploadFileOptions())
 					Ω(err).ShouldNot(HaveOccurred())
 
 					err = os.Remove(tempFile.Name())
@@ -368,13 +368,13 @@ var _ = Describe("check", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					tempFile.Close()
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-2"), tempFile.Name(), "private", "", "")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-2"), tempFile.Name(), s3resource.NewUploadFileOptions())
 					Ω(err).ShouldNot(HaveOccurred())
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-1"), tempFile.Name(), "private", "", "")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-1"), tempFile.Name(), s3resource.NewUploadFileOptions())
 					Ω(err).ShouldNot(HaveOccurred())
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-3"), tempFile.Name(), "private", "", "")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-does-match-3"), tempFile.Name(), s3resource.NewUploadFileOptions())
 					Ω(err).ShouldNot(HaveOccurred())
 
 					err = os.Remove(tempFile.Name())
@@ -422,16 +422,16 @@ var _ = Describe("check", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					tempFile.Close()
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-1.2.0-rc.2"), tempFile.Name(), "private", "", "")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-1.2.0-rc.2"), tempFile.Name(), s3resource.NewUploadFileOptions())
 					Ω(err).ShouldNot(HaveOccurred())
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-1.2.0-rc.1"), tempFile.Name(), "private", "", "")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-1.2.0-rc.1"), tempFile.Name(), s3resource.NewUploadFileOptions())
 					Ω(err).ShouldNot(HaveOccurred())
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-1.1.0-rc.1"), tempFile.Name(), "private", "", "")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-1.1.0-rc.1"), tempFile.Name(), s3resource.NewUploadFileOptions())
 					Ω(err).ShouldNot(HaveOccurred())
 
-					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-1.1.0-rc.2"), tempFile.Name(), "private", "", "")
+					_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "file-1.1.0-rc.2"), tempFile.Name(), s3resource.NewUploadFileOptions())
 					Ω(err).ShouldNot(HaveOccurred())
 
 					err = os.Remove(tempFile.Name())
@@ -489,7 +489,7 @@ var _ = Describe("check", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					tempFile.Close()
 
-					_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "file-does-not-match"), tempFile.Name(), "private", "", "")
+					_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "file-does-not-match"), tempFile.Name(), s3resource.NewUploadFileOptions())
 					Ω(err).ShouldNot(HaveOccurred())
 
 					err = os.Remove(tempFile.Name())
@@ -535,13 +535,13 @@ var _ = Describe("check", func() {
 						Ω(err).ShouldNot(HaveOccurred())
 						tempFile.Close()
 
-						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private", "", "")
+						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), s3resource.NewUploadFileOptions())
 						Ω(err).ShouldNot(HaveOccurred())
 
-						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private", "", "")
+						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), s3resource.NewUploadFileOptions())
 						Ω(err).ShouldNot(HaveOccurred())
 
-						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private", "", "")
+						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), s3resource.NewUploadFileOptions())
 						Ω(err).ShouldNot(HaveOccurred())
 
 						checkRequest.Source.VersionedFile = filepath.Join(directoryPrefix, "versioned-file")
@@ -598,13 +598,13 @@ var _ = Describe("check", func() {
 						Ω(err).ShouldNot(HaveOccurred())
 						tempFile.Close()
 
-						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private", "", "")
+						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), s3resource.NewUploadFileOptions())
 						Ω(err).ShouldNot(HaveOccurred())
 
-						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private", "", "")
+						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), s3resource.NewUploadFileOptions())
 						Ω(err).ShouldNot(HaveOccurred())
 
-						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), "private", "", "")
+						_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "versioned-file"), tempFile.Name(), s3resource.NewUploadFileOptions())
 						Ω(err).ShouldNot(HaveOccurred())
 
 						checkRequest.Source.VersionedFile = filepath.Join(directoryPrefix, "versioned-file")

--- a/integration/in_test.go
+++ b/integration/in_test.go
@@ -111,7 +111,7 @@ var _ = Describe("in", func() {
 				err = ioutil.WriteFile(tempFile.Name(), []byte(fmt.Sprintf("some-file-%d", i)), 0755)
 				Ω(err).ShouldNot(HaveOccurred())
 
-				_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, fmt.Sprintf("some-file-%d", i)), tempFile.Name(), "private", "", "")
+				_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, fmt.Sprintf("some-file-%d", i)), tempFile.Name(), s3resource.NewUploadFileOptions())
 				Ω(err).ShouldNot(HaveOccurred())
 			}
 
@@ -192,7 +192,7 @@ var _ = Describe("in", func() {
 				err = ioutil.WriteFile(tempFile.Name(), []byte(fmt.Sprintf("some-file-%d", i)), 0755)
 				Ω(err).ShouldNot(HaveOccurred())
 
-				_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "some-file"), tempFile.Name(), "private", "", "")
+				_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "some-file"), tempFile.Name(), s3resource.NewUploadFileOptions())
 				Ω(err).ShouldNot(HaveOccurred())
 			}
 			err = os.Remove(tempFile.Name())
@@ -290,7 +290,7 @@ var _ = Describe("in", func() {
 				err = ioutil.WriteFile(tempFile.Name(), []byte(fmt.Sprintf("some-file-%d", i)), 0755)
 				Ω(err).ShouldNot(HaveOccurred())
 
-				_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, fmt.Sprintf("some-file-%d", i)), tempFile.Name(), "private", "", "")
+				_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, fmt.Sprintf("some-file-%d", i)), tempFile.Name(), s3resource.NewUploadFileOptions())
 				Ω(err).ShouldNot(HaveOccurred())
 			}
 

--- a/integration/s3client_test.go
+++ b/integration/s3client_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/concourse/s3-resource"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -57,16 +58,18 @@ var _ = Describe("S3client", func() {
 	})
 
 	It("can interact with buckets", func() {
-		_, err := s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "file-to-upload-1"), tempFile.Name(), "private", "", "")
+		_, err := s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "file-to-upload-1"), tempFile.Name(), s3resource.NewUploadFileOptions())
 		Ω(err).ShouldNot(HaveOccurred())
 
-		_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "file-to-upload-2"), tempFile.Name(), "private", "", "")
+		_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "file-to-upload-2"), tempFile.Name(), s3resource.NewUploadFileOptions())
 		Ω(err).ShouldNot(HaveOccurred())
 
-		_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "file-to-upload-2"), tempFile.Name(), "private", "", "")
+		_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "file-to-upload-2"), tempFile.Name(), s3resource.NewUploadFileOptions())
 		Ω(err).ShouldNot(HaveOccurred())
 
-		_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "file-to-upload-3"), tempFile.Name(), "private", "AES256", "")
+		options := s3resource.NewUploadFileOptions()
+		options.ServerSideEncryption = "AES256"
+		_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "file-to-upload-3"), tempFile.Name(), options)
 		Ω(err).ShouldNot(HaveOccurred())
 
 		files, err := s3client.BucketFiles(versionedBucketName, directoryPrefix)

--- a/out/models.go
+++ b/out/models.go
@@ -10,10 +10,11 @@ type OutRequest struct {
 }
 
 type Params struct {
-	From string `json:"from"`
-	File string `json:"file"`
-	To   string `json:"to"`
-	Acl  string `json:"acl"`
+	From        string `json:"from"`
+	File        string `json:"file"`
+	To          string `json:"to"`
+	Acl         string `json:"acl"`
+	ContentType string `json:"content-type"`
 }
 
 type OutResponse struct {

--- a/out/models.go
+++ b/out/models.go
@@ -14,7 +14,7 @@ type Params struct {
 	File        string `json:"file"`
 	To          string `json:"to"`
 	Acl         string `json:"acl"`
-	ContentType string `json:"content-type"`
+	ContentType string `json:"content_type"`
 }
 
 type OutResponse struct {

--- a/out/out_command.go
+++ b/out/out_command.go
@@ -61,10 +61,7 @@ func (command *OutCommand) Run(sourceDir string, request OutRequest) (OutRespons
 		options.Acl = request.Params.Acl
 	}
 
-	if request.Params.ContentType != "" {
-		options.ContentType = request.Params.ContentType
-	}
-
+	options.ContentType = request.Params.ContentType
 	options.ServerSideEncryption = request.Source.ServerSideEncryption
 	options.KmsKeyId = request.Source.SSEKMSKeyId
 

--- a/out/out_command.go
+++ b/out/out_command.go
@@ -55,18 +55,20 @@ func (command *OutCommand) Run(sourceDir string, request OutRequest) (OutRespons
 
 	bucketName := request.Source.Bucket
 
-	acl := "private"
+	options := s3resource.NewUploadFileOptions()
+
 	if request.Params.Acl != "" {
-		acl = request.Params.Acl
+		options.Acl = request.Params.Acl
 	}
+
+	options.ServerSideEncryption = 	request.Source.ServerSideEncryption
+	options.KmsKeyId = request.Source.SSEKMSKeyId
 
 	versionID, err := command.s3client.UploadFile(
 		bucketName,
 		remotePath,
 		localPath,
-		acl,
-		request.Source.ServerSideEncryption,
-		request.Source.SSEKMSKeyId,
+		options,
 	)
 	if err != nil {
 		return OutResponse{}, err

--- a/out/out_command.go
+++ b/out/out_command.go
@@ -61,7 +61,11 @@ func (command *OutCommand) Run(sourceDir string, request OutRequest) (OutRespons
 		options.Acl = request.Params.Acl
 	}
 
-	options.ServerSideEncryption = 	request.Source.ServerSideEncryption
+	if request.Params.ContentType != "" {
+		options.ContentType = request.Params.ContentType
+	}
+
+	options.ServerSideEncryption = request.Source.ServerSideEncryption
 	options.KmsKeyId = request.Source.SSEKMSKeyId
 
 	versionID, err := command.s3client.UploadFile(

--- a/out/out_command_test.go
+++ b/out/out_command_test.go
@@ -351,5 +351,40 @@ var _ = Describe("Out Command", func() {
 				Ω(response.Metadata[0].Name).ShouldNot(Equal("url"))
 			})
 		})
+
+		Context("when specifying a content-type for the uploaded file", func() {
+			BeforeEach(func() {
+				request.Params.File = "a/*.tgz"
+				request.Params.ContentType = "application/customtype"
+				createFile("a/file.tgz")
+			})
+
+			It("applies the specfied content-type", func() {
+				_, err := command.Run(sourceDir, request)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Ω(s3client.UploadFileCallCount()).Should(Equal(1))
+				_, _, _, options := s3client.UploadFileArgsForCall(0)
+
+				Ω(options.ContentType).Should(Equal("application/customtype"))
+			})
+		})
+
+		Context("content-type is not specified for the uploaded file", func() {
+			BeforeEach(func() {
+				request.Params.File = "a/*.tgz"
+				createFile("a/file.tgz")
+			})
+
+			It("no content-type specified leaves an empty content-type", func() {
+				_, err := command.Run(sourceDir, request)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Ω(s3client.UploadFileCallCount()).Should(Equal(1))
+				_, _, _, options := s3client.UploadFileArgsForCall(0)
+
+				Ω(options.ContentType).Should(Equal(""))
+			})
+		})
 	})
 })

--- a/out/out_command_test.go
+++ b/out/out_command_test.go
@@ -146,12 +146,12 @@ var _ = Describe("Out Command", func() {
 				Ω(err).ShouldNot(HaveOccurred())
 
 				Ω(s3client.UploadFileCallCount()).Should(Equal(1))
-				bucketName, remotePath, localPath, acl := s3client.UploadFileArgsForCall(0)
+				bucketName, remotePath, localPath, options := s3client.UploadFileArgsForCall(0)
 
 				Ω(bucketName).Should(Equal("bucket-name"))
 				Ω(remotePath).Should(Equal("file.tgz"))
 				Ω(localPath).Should(Equal(filepath.Join(sourceDir, "a/file.tgz")))
-				Ω(acl).Should(Equal("private"))
+				Ω(options).Should(Equal(s3resource.UploadFileOptions{Acl: "private"}))
 			})
 		})
 
@@ -167,12 +167,13 @@ var _ = Describe("Out Command", func() {
 				Ω(err).ShouldNot(HaveOccurred())
 
 				Ω(s3client.UploadFileCallCount()).Should(Equal(1))
-				bucketName, remotePath, localPath, acl := s3client.UploadFileArgsForCall(0)
+				bucketName, remotePath, localPath, options := s3client.UploadFileArgsForCall(0)
 
 				Ω(bucketName).Should(Equal("bucket-name"))
 				Ω(remotePath).Should(Equal("file.tgz"))
 				Ω(localPath).Should(Equal(filepath.Join(sourceDir, "a/file.tgz")))
-				Ω(acl).Should(Equal("public-read"))
+				Ω(options).Should(Equal(s3resource.UploadFileOptions{Acl: "public-read"}))
+
 			})
 		})
 
@@ -196,12 +197,12 @@ var _ = Describe("Out Command", func() {
 				Ω(err).ShouldNot(HaveOccurred())
 
 				Ω(s3client.UploadFileCallCount()).Should(Equal(1))
-				bucketName, remotePath, localPath, acl := s3client.UploadFileArgsForCall(0)
+				bucketName, remotePath, localPath, options := s3client.UploadFileArgsForCall(0)
 
 				Ω(bucketName).Should(Equal("bucket-name"))
 				Ω(remotePath).Should(Equal("a-folder/file.tgz"))
 				Ω(localPath).Should(Equal(filepath.Join(sourceDir, "a/file.tgz")))
-				Ω(acl).Should(Equal("private"))
+				Ω(options).Should(Equal(s3resource.UploadFileOptions{Acl: "private"}))
 			})
 		})
 
@@ -217,12 +218,12 @@ var _ = Describe("Out Command", func() {
 				Ω(err).ShouldNot(HaveOccurred())
 
 				Ω(s3client.UploadFileCallCount()).Should(Equal(1))
-				bucketName, remotePath, localPath, acl := s3client.UploadFileArgsForCall(0)
+				bucketName, remotePath, localPath, options := s3client.UploadFileArgsForCall(0)
 
 				Ω(bucketName).Should(Equal("bucket-name"))
 				Ω(remotePath).Should(Equal("file.tgz"))
 				Ω(localPath).Should(Equal(filepath.Join(sourceDir, "a/file.tgz")))
-				Ω(acl).Should(Equal("private"))
+				Ω(options).Should(Equal(s3resource.UploadFileOptions{Acl: "private"}))
 			})
 		})
 
@@ -238,12 +239,12 @@ var _ = Describe("Out Command", func() {
 				Ω(err).ShouldNot(HaveOccurred())
 
 				Ω(s3client.UploadFileCallCount()).Should(Equal(1))
-				bucketName, remotePath, localPath, acl := s3client.UploadFileArgsForCall(0)
+				bucketName, remotePath, localPath, options := s3client.UploadFileArgsForCall(0)
 
 				Ω(bucketName).Should(Equal("bucket-name"))
 				Ω(remotePath).Should(Equal("folder-123/file.tgz"))
 				Ω(localPath).Should(Equal(filepath.Join(sourceDir, "a/file-123.tgz")))
-				Ω(acl).Should(Equal("private"))
+				Ω(options).Should(Equal(s3resource.UploadFileOptions{Acl: "private"}))
 
 				Ω(response.Version.Path).Should(Equal("folder-123/file.tgz"))
 
@@ -270,12 +271,12 @@ var _ = Describe("Out Command", func() {
 				Ω(err).ShouldNot(HaveOccurred())
 
 				Ω(s3client.UploadFileCallCount()).Should(Equal(1))
-				bucketName, remotePath, localPath, acl := s3client.UploadFileArgsForCall(0)
+				bucketName, remotePath, localPath, options := s3client.UploadFileArgsForCall(0)
 
 				Ω(bucketName).Should(Equal("bucket-name"))
 				Ω(remotePath).Should(Equal(remoteFileName))
 				Ω(localPath).Should(Equal(filepath.Join(sourceDir, localFileName)))
-				Ω(acl).Should(Equal("private"))
+				Ω(options).Should(Equal(s3resource.UploadFileOptions{Acl: "private"}))
 
 				Ω(response.Version.VersionID).Should(Equal("123"))
 
@@ -294,11 +295,12 @@ var _ = Describe("Out Command", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Ω(s3client.UploadFileCallCount()).Should(Equal(1))
-				bucketName, remotePath, localPath, acl := s3client.UploadFileArgsForCall(0)
+
+				bucketName, remotePath, localPath, options := s3client.UploadFileArgsForCall(0)
 				Expect(bucketName).To(Equal("bucket-name"))
 				Expect(remotePath).To(Equal("a-folder/special-file.tgz"))
 				Expect(localPath).To(Equal(filepath.Join(sourceDir, "my/special-file.tgz")))
-				Ω(acl).Should(Equal("private"))
+				Ω(options).Should(Equal(s3resource.UploadFileOptions{Acl: "private"}))
 
 				Expect(response.Metadata[0].Name).To(Equal("filename"))
 				Expect(response.Metadata[0].Value).To(Equal("special-file.tgz"))

--- a/s3client.go
+++ b/s3client.go
@@ -45,6 +45,7 @@ type UploadFileOptions struct {
 	Acl                  string
 	ServerSideEncryption string
 	KmsKeyId             string
+	ContentType          string
 }
 
 func NewUploadFileOptions() UploadFileOptions {
@@ -179,6 +180,9 @@ func (client *s3client) UploadFile(bucketName string, remotePath string, localPa
 	}
 	if options.KmsKeyId != "" {
 		uploadInput.SSEKMSKeyId = aws.String(options.KmsKeyId)
+	}
+	if options.ContentType != "" {
+		uploadInput.ContentType = aws.String(options.ContentType)
 	}
 
 	uploadOutput, err := uploader.Upload(&uploadInput)

--- a/scripts/test
+++ b/scripts/test
@@ -16,6 +16,4 @@ fi
 
 cd $s3_resource_dir
 
-counterfeiter -o fakes/fake_s3client.go .  S3Client
-
 ginkgo -r -p -skipPackage integration

--- a/scripts/test
+++ b/scripts/test
@@ -15,4 +15,7 @@ if not_installed ginkgo; then
 fi
 
 cd $s3_resource_dir
+
+counterfeiter -o fakes/fake_s3client.go .  S3Client
+
 ginkgo -r -p -skipPackage integration


### PR DESCRIPTION
Based on a suggestion in https://github.com/concourse/s3-resource/pull/52 , we refactored the UploadFile parameters to use a struct for the option list.
