### PR TITLE
Implement support for "git-describe" commits-since-tag versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ One of the following two options must be specified:
   Semantic versions, or just numbers, are supported. Accordingly, full regular
   expressions are supported, to specify the capture groups.
 
+  In addition, a capture group named `commits_since_version` may be specified,
+  which is the number of commits since the above specified version in the
+  convention of `git-describe`. Your regexp should not additionally pass the
+  `git-describe`-appended short hash.
+
 * `versioned_file`: *Optional* If you enable versioning for your S3 bucket then
   you can keep the file name the same and upload new versions of your file
   without resorting to version numbers. This property is the path to the file


### PR DESCRIPTION
In my workflow, I use git tags (with semantic versioning) to mark final releases, but I use `git-describe` to version incremental commits automatically. For example, if my most recent tag is `v0.3.1` and I am 100 commits past that, a `git-describe` output would look something like `v0.3.1-100-gffb5d92`.

Unfortunately, this doesn't play well with semver, which dictates that anything past the major/minor/patch triple is considered a _pre_release, not a _post_release. Hence, `0.3.1-100-gffb5d92` is considered to be _before_ `0.3.1`, which is inconvenient for my use-case. This was [reported to the semver project in 2013](https://github.com/mojombo/semver/issues/106) and they explicitly do not want to support this use-case.

This pull requests adds a new regex capture group, "commits_since_version", which handles the ordering correctly. It is entirely optional and does not affect the existing ordering and versioning.

I'm quite new to Go, so I may have made some elementary mistakes here.
