### PR TITLE
Allow non_anonymous S3 access without specified keypair (i.e. instance profile)

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -18,6 +18,7 @@ func main() {
 		request.Source.RegionName,
 		request.Source.Endpoint,
 		request.Source.DisableSSL,
+		request.Source.NotAnonymous,
 	)
 
 	client := s3resource.NewS3Client(

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -29,6 +29,7 @@ func main() {
 		request.Source.RegionName,
 		request.Source.Endpoint,
 		request.Source.DisableSSL,
+		request.Source.NotAnonymous,
 	)
 
 	if len(request.Source.CloudfrontURL) != 0 {

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -25,6 +25,7 @@ func main() {
 		request.Source.RegionName,
 		request.Source.Endpoint,
 		request.Source.DisableSSL,
+		request.Source.NotAnonymous,
 	)
 
 	client := s3resource.NewS3Client(

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -78,6 +78,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		regionName,
 		endpoint,
 		false,
+		false,
 	)
 
 	s3Service = s3.New(session.New(awsConfig), awsConfig)

--- a/models.go
+++ b/models.go
@@ -14,6 +14,7 @@ type Source struct {
 	ServerSideEncryption string `json:"server_side_encryption"`
 	SSEKMSKeyId          string `json:"sse_kms_key_id"`
 	UseV2Signing         bool   `json:"use_v2_signing"`
+	NotAnonymous         bool   `json:"non_anonymous"`
 }
 
 func (source Source) IsValid() (bool, string) {

--- a/s3client.go
+++ b/s3client.go
@@ -80,26 +80,28 @@ func NewAwsConfig(
 	regionName string,
 	endpoint string,
 	disableSSL bool,
+  notAnonymous bool,
 ) *aws.Config {
-	var creds *credentials.Credentials
-
-	if accessKey == "" && secretKey == "" {
-		creds = credentials.AnonymousCredentials
-	} else {
-		creds = credentials.NewStaticCredentials(accessKey, secretKey, "")
-	}
-
 	if len(regionName) == 0 {
 		regionName = "us-east-1"
 	}
 
 	awsConfig := &aws.Config{
 		Region:           aws.String(regionName),
-		Credentials:      creds,
 		S3ForcePathStyle: aws.Bool(true),
 		MaxRetries:       aws.Int(maxRetries),
 		DisableSSL:       aws.Bool(disableSSL),
 	}
+
+  if (accessKey != "" && secretKey != "") || !notAnonymous {
+    var creds *credentials.Credentials
+    if !notAnonymous {
+      creds = credentials.AnonymousCredentials
+    } else {
+      creds = credentials.NewStaticCredentials(accessKey, secretKey, "")
+    }
+    awsConfig.Credentials = creds
+  }
 
 	if len(endpoint) != 0 {
 		endpoint := fmt.Sprintf("%s", endpoint)


### PR DESCRIPTION
This is @robbruce's commit to fix #65 ; I've built it and confirmed that it works as expected.