### PR TITLE
add skip_ssl_verification source configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ version numbers.
 * `disable_ssl`: *Optional.* Disable SSL for the endpoint, useful for S3
   compatible providers without SSL.
 
+* `skip_ssl_verification`: *Optional.* Skip SSL verification for S3 endpoint. Useful for S3 compatible providers using self-signed SSL certificates.
+
 * `server_side_encryption`: *Optional.* An encryption algorithm to use when
   storing objects in S3.
 
 * `sse_kms_key_id`: *Optional.* The ID of the AWS KMS master encryption key
   used for the object.
-
 
 * `use_v2_signing`: *Optional.* Use signature v2 signing, useful for S3 compatible providers that do not support v4.
 

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -18,6 +18,7 @@ func main() {
 		request.Source.RegionName,
 		request.Source.Endpoint,
 		request.Source.DisableSSL,
+		request.Source.SkipSSLVerification,
 	)
 
 	client := s3resource.NewS3Client(

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -29,6 +29,7 @@ func main() {
 		request.Source.RegionName,
 		request.Source.Endpoint,
 		request.Source.DisableSSL,
+		request.Source.SkipSSLVerification,
 	)
 
 	if len(request.Source.CloudfrontURL) != 0 {

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -25,6 +25,7 @@ func main() {
 		request.Source.RegionName,
 		request.Source.Endpoint,
 		request.Source.DisableSSL,
+		request.Source.SkipSSLVerification,
 	)
 
 	client := s3resource.NewS3Client(

--- a/models.go
+++ b/models.go
@@ -14,6 +14,7 @@ type Source struct {
 	ServerSideEncryption string `json:"server_side_encryption"`
 	SSEKMSKeyId          string `json:"sse_kms_key_id"`
 	UseV2Signing         bool   `json:"use_v2_signing"`
+	SkipSSLVerification  bool   `json:"skip_ssl_verification"`
 }
 
 func (source Source) IsValid() (bool, string) {


### PR DESCRIPTION
`disable_ssl` supports http endpoints but does not disable validation for https endpoints using self-signed certs.

This commit adds a new source configuration parameter `skip_ssl_verification`.