### PR TITLE
Add unpack ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Places the following files in the destination:
 
 #### Parameters
 
-*None.*
+* `unpack`: *Optional.* If true and the file is an archive (tar, gzipped tar, other gzipped file, or zip), unpack the file. Gzipped tarballs will be both ungzipped and untarred.
 
 
 ### `out`: Upload an object to the bucket.

--- a/in/archive.go
+++ b/in/archive.go
@@ -1,0 +1,76 @@
+package in
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"bitbucket.org/taruti/mimemagic"
+)
+
+var archiveMimetypes = []string{
+	"application/x-gzip",
+	"application/gzip",
+	"application/x-tar",
+	"application/zip",
+}
+
+func mimetype(r *bufio.Reader) (string, error) {
+	bs, err := r.Peek(512)
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+
+	if len(bs) == 0 {
+		return "", errors.New("cannot determine mimetype from empty bytes")
+	}
+
+	return mimemagic.Match("", bs), nil
+}
+
+func archiveMimetype(filename string) string {
+	f, err := os.Open(filename)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	mime, err := mimetype(bufio.NewReader(f))
+	if err != nil {
+		return ""
+	}
+
+	for i := range archiveMimetypes {
+		if strings.HasPrefix(mime, archiveMimetypes[i]) {
+			return archiveMimetypes[i]
+		}
+	}
+
+	return ""
+}
+
+func inflate(mime, path, destination string) error {
+	var cmd *exec.Cmd
+
+	switch mime {
+	case "application/zip":
+		cmd = exec.Command("unzip", "-P", "", "-d", destination, path)
+		defer os.Remove(path)
+
+	case "application/x-tar":
+		cmd = exec.Command("tar", "xf", path, "-C", destination)
+		defer os.Remove(path)
+
+	case "application/gzip", "application/x-gzip":
+		cmd = exec.Command("gunzip", path)
+
+	default:
+		return fmt.Errorf("don't know how to extract %s", mime)
+	}
+
+	return cmd.Run()
+}

--- a/in/in_command_test.go
+++ b/in/in_command_test.go
@@ -34,10 +34,10 @@ var _ = Describe("In Command", func() {
 			request = InRequest{
 				Source: s3resource.Source{
 					Bucket: "bucket-name",
-					Regexp: "files/a-file-(.*).tgz",
+					Regexp: "files/a-file-(.*)",
 				},
 				Version: s3resource.Version{
-					Path: "files/a-file-1.3.tgz",
+					Path: "files/a-file-1.3",
 				},
 			}
 
@@ -74,7 +74,7 @@ var _ = Describe("In Command", func() {
 
 		Context("when there is an existing version in the request", func() {
 			BeforeEach(func() {
-				request.Version.Path = "files/a-file-1.3.tgz"
+				request.Version.Path = "files/a-file-1.3"
 			})
 
 			It("downloads the existing version of the file", func() {
@@ -85,9 +85,9 @@ var _ = Describe("In Command", func() {
 				bucketName, remotePath, versionID, localPath := s3client.DownloadFileArgsForCall(0)
 
 				Ω(bucketName).Should(Equal("bucket-name"))
-				Ω(remotePath).Should(Equal("files/a-file-1.3.tgz"))
+				Ω(remotePath).Should(Equal("files/a-file-1.3"))
 				Ω(versionID).Should(BeEmpty())
-				Ω(localPath).Should(Equal(filepath.Join(destDir, "a-file-1.3.tgz")))
+				Ω(localPath).Should(Equal(filepath.Join(destDir, "a-file-1.3")))
 			})
 
 			It("creates a 'url' file that contains the URL", func() {
@@ -104,7 +104,7 @@ var _ = Describe("In Command", func() {
 
 				bucketName, remotePath, private, versionID := s3client.URLArgsForCall(0)
 				Ω(bucketName).Should(Equal("bucket-name"))
-				Ω(remotePath).Should(Equal("files/a-file-1.3.tgz"))
+				Ω(remotePath).Should(Equal("files/a-file-1.3"))
 				Ω(private).Should(Equal(false))
 				Ω(versionID).Should(BeEmpty())
 			})
@@ -129,7 +129,7 @@ var _ = Describe("In Command", func() {
 					Ω(s3client.URLCallCount()).Should(Equal(1))
 					bucketName, remotePath, private, versionID := s3client.URLArgsForCall(0)
 					Ω(bucketName).Should(Equal("bucket-name"))
-					Ω(remotePath).Should(Equal("files/a-file-1.3.tgz"))
+					Ω(remotePath).Should(Equal("files/a-file-1.3"))
 					Ω(private).Should(Equal(true))
 					Ω(versionID).Should(BeEmpty())
 				})
@@ -153,7 +153,7 @@ var _ = Describe("In Command", func() {
 					response, err := command.Run(destDir, request)
 					Ω(err).ShouldNot(HaveOccurred())
 
-					Ω(response.Version.Path).Should(Equal("files/a-file-1.3.tgz"))
+					Ω(response.Version.Path).Should(Equal("files/a-file-1.3"))
 				})
 
 				It("has metadata about the file", func() {
@@ -161,7 +161,7 @@ var _ = Describe("In Command", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 
 					Ω(response.Metadata[0].Name).Should(Equal("filename"))
-					Ω(response.Metadata[0].Value).Should(Equal("a-file-1.3.tgz"))
+					Ω(response.Metadata[0].Value).Should(Equal("a-file-1.3"))
 
 					Ω(response.Metadata[1].Name).Should(Equal("url"))
 					Ω(response.Metadata[1].Value).Should(Equal("http://google.com"))
@@ -192,7 +192,7 @@ var _ = Describe("In Command", func() {
 				_, err := command.Run(destDir, request)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("regex does not match provided version"))
-				Expect(err.Error()).To(ContainSubstring("files/a-file-1.3.tgz"))
+				Expect(err.Error()).To(ContainSubstring("files/a-file-1.3"))
 			})
 		})
 	})

--- a/in/models.go
+++ b/in/models.go
@@ -5,6 +5,11 @@ import "github.com/concourse/s3-resource"
 type InRequest struct {
 	Source  s3resource.Source  `json:"source"`
 	Version s3resource.Version `json:"version"`
+	Params  Params             `json:"params"`
+}
+
+type Params struct {
+	Unpack bool `json:"unpack"`
 }
 
 type InResponse struct {


### PR DESCRIPTION
When `unpack` is true and the file can be determined to be an archive it knows how to handle, the resource will unpack the archive to the destination directory after downloading it.

The way it works is by downloading the file the destination dir when the flag is set, and then if it's an archive it extracts it. If the archive is a .tar.gz it will unpack the tar after gunzipping it. The original archive is not saved.

This _should_ mean that when the `unpack` option is used the unpacked archive is cached in baggageclaim, which can be a benefit when downloading large zip files that get unpacked multiple times by different jobs.

This should also mean that this resource can be used as  an `image_resource`[*](https://github.com/concourse/concourse/issues/1369), where your archive lays out the appopriate filesystem to be used for that case, which is having a root `rootfs` directory and metadata.json file as created by docker-image-resource after a `get`.