### PR TITLE
Add chained credentials

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,0 @@
-Dockerfile

--- a/README.md
+++ b/README.md
@@ -7,14 +7,13 @@ version numbers.
 
 * `bucket`: *Required.* The name of the bucket.
 
-* `access_key_id`: *Optional.* The AWS access key to use when accessing the
-  bucket.
+* `access_key_id`: *Optional.* The AWS access key to use when accessing the bucket.
 
-* `secret_access_key`: *Optional.* The AWS secret key to use when accessing
-  the bucket.
+* `secret_access_key`: *Optional.* The AWS secret key to use when accessing the bucket.
 
-* `session_token`: *Optional.* The AWS STS session token to use when
-  accessing the bucket.
+* `session_token`: *Optional.* The AWS STS session token to use when accessing the bucket.
+
+* `assume_role_arn`: *Optional.* If you are running Concourse on AWS, and would like to assume role after authentication, provide the ARN here.
 
 * `region_name`: *Optional.* The region the bucket is in. Defaults to
   `us-east-1`.
@@ -44,6 +43,16 @@ version numbers.
   used for the object.
 
 * `use_v2_signing`: *Optional.* Use signature v2 signing, useful for S3 compatible providers that do not support v4.
+
+### Authentication
+
+This resource will attempt to authenticate with these methods in order:
+
+1. `access_key_id` and `secret_access_key`
+2. `session_token`
+3. EC2Role (implicit)
+
+If `assume_role` is provided, it will then attempt to assume role using the above credentials that are valid.
 
 ### File Names
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ version numbers.
 
 * `session_token`: *Optional.* The AWS STS session token to use when accessing the bucket.
 
-* `assume_role_arn`: *Optional.* If you are running Concourse on AWS, and would like to assume role after authentication, provide the ARN here.
+* `assume_role_arn`: *Optional.* To assume role after authentication, provide the role ARN here.
 
 * `region_name`: *Optional.* The region the bucket is in. Defaults to
   `us-east-1`.
@@ -50,7 +50,7 @@ This resource will attempt to authenticate with these methods in order:
 
 1. `access_key_id` and `secret_access_key`
 2. `session_token`
-3. EC2Role (implicit)
+3. EC2 Role (if concourse is running on AWS)
 
 If `assume_role` is provided, it will then attempt to assume role using the above credentials that are valid.
 

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -12,15 +12,18 @@ func main() {
 	var request check.CheckRequest
 	inputRequest(&request)
 
-	awsConfig := s3resource.NewAwsConfig(
-		request.Source.AccessKeyID,
-		request.Source.SecretAccessKey,
-		request.Source.SessionToken,
-		request.Source.RegionName,
-		request.Source.Endpoint,
-		request.Source.DisableSSL,
-		request.Source.SkipSSLVerification,
-	)
+	b := s3resource.AwsConfigBuilder{
+		AccessKey: request.Source.AccessKeyID,
+		SecretKey: request.Source.SecretAccessKey,
+		SessionToken: request.Source.SessionToken,
+		RegionName: request.Source.RegionName,
+		Endpoint: request.Source.Endpoint,
+		DisableSSL: request.Source.DisableSSL,
+		SkipSSLVerification: request.Source.SkipSSLVerification,
+		AssumeRoleArn: request.Source.AssumeRoleArn,
+	}
+
+	awsConfig := b.Build()
 
 	client := s3resource.NewS3Client(
 		os.Stderr,

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -24,15 +24,18 @@ func main() {
 	var request in.InRequest
 	inputRequest(&request)
 
-	awsConfig := s3resource.NewAwsConfig(
-		request.Source.AccessKeyID,
-		request.Source.SecretAccessKey,
-		request.Source.SessionToken,
-		request.Source.RegionName,
-		request.Source.Endpoint,
-		request.Source.DisableSSL,
-		request.Source.SkipSSLVerification,
-	)
+	b := s3resource.AwsConfigBuilder{
+		AccessKey: request.Source.AccessKeyID,
+		SecretKey: request.Source.SecretAccessKey,
+		SessionToken: request.Source.SessionToken,
+		RegionName: request.Source.RegionName,
+		Endpoint: request.Source.Endpoint,
+		DisableSSL: request.Source.DisableSSL,
+		SkipSSLVerification: request.Source.SkipSSLVerification,
+		AssumeRoleArn: request.Source.AssumeRoleArn,
+	}
+
+	awsConfig := b.Build()
 
 	if len(request.Source.CloudfrontURL) != 0 {
 		cloudfrontUrl, err := url.ParseRequestURI(request.Source.CloudfrontURL)

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -19,15 +19,18 @@ func main() {
 
 	sourceDir := os.Args[1]
 
-	awsConfig := s3resource.NewAwsConfig(
-		request.Source.AccessKeyID,
-		request.Source.SecretAccessKey,
-		request.Source.SessionToken,
-		request.Source.RegionName,
-		request.Source.Endpoint,
-		request.Source.DisableSSL,
-		request.Source.SkipSSLVerification,
-	)
+	b := s3resource.AwsConfigBuilder{
+		AccessKey: request.Source.AccessKeyID,
+		SecretKey: request.Source.SecretAccessKey,
+		SessionToken: request.Source.SessionToken,
+		RegionName: request.Source.RegionName,
+		Endpoint: request.Source.Endpoint,
+		DisableSSL: request.Source.DisableSSL,
+		SkipSSLVerification: request.Source.SkipSSLVerification,
+		AssumeRoleArn: request.Source.AssumeRoleArn,
+	}
+
+	awsConfig := b.Build()
 
 	client := s3resource.NewS3Client(
 		os.Stderr,

--- a/models.go
+++ b/models.go
@@ -16,6 +16,7 @@ type Source struct {
 	SSEKMSKeyId          string `json:"sse_kms_key_id"`
 	UseV2Signing         bool   `json:"use_v2_signing"`
 	SkipSSLVerification  bool   `json:"skip_ssl_verification"`
+	AssumeRoleArn        string `json:"assume_role_arn"`
 }
 
 func (source Source) IsValid() (bool, string) {

--- a/s3client.go
+++ b/s3client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -80,6 +81,80 @@ func NewS3Client(
 	}
 }
 
+type AwsConfigBuilder struct {
+	AccessKey           string
+	SecretKey           string
+	SessionToken        string
+	RegionName          string
+	Endpoint            string
+	DisableSSL          bool
+	AssumeRoleArn       string
+	SkipSSLVerification bool
+}
+
+func (b *AwsConfigBuilder) Build() *aws.Config {
+	var providers []credentials.Provider
+	var creds *credentials.Credentials
+
+	if b.AccessKey != "" {
+		creds := &credentials.StaticProvider{
+			Value: credentials.Value{
+				AccessKeyID:     b.AccessKey,
+				SecretAccessKey: b.SecretKey,
+				SessionToken:    b.SessionToken,
+				ProviderName:    "Statically Defined",
+			},
+		}
+		providers = append(providers, creds)
+	} else {
+		providers = append(providers, &credentials.StaticProvider{})
+	}
+
+	sess := session.Must(session.NewSession())
+
+	providers = append(providers, &ec2rolecreds.EC2RoleProvider{
+		Client: ec2metadata.New(sess),
+	})
+
+	creds = credentials.NewChainCredentials(providers)
+
+	if len(b.RegionName) == 0 {
+		b.RegionName = "us-east-1"
+	}
+
+	var httpClient *http.Client
+	if b.SkipSSLVerification {
+		httpClient = &http.Client{Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}}
+	} else {
+		httpClient = http.DefaultClient
+	}
+
+	awsConfig := &aws.Config{
+		Region:           aws.String(b.RegionName),
+		Credentials:      creds,
+		S3ForcePathStyle: aws.Bool(true),
+		MaxRetries:       aws.Int(maxRetries),
+		DisableSSL:       aws.Bool(b.DisableSSL),
+		HTTPClient:       httpClient,
+	}
+
+	if len(b.Endpoint) != 0 {
+		endpoint := fmt.Sprintf("%s", b.Endpoint)
+		awsConfig.Endpoint = &endpoint
+	}
+
+	if b.AssumeRoleArn != "" {
+		sess := session.Must(session.NewSession(awsConfig))
+		creds := stscreds.NewCredentials(sess, b.AssumeRoleArn)
+		awsConfig.Credentials = creds
+	}
+
+	return awsConfig
+}
+
+// Deprecated: use AwsConfigBuilder instead
 func NewAwsConfig(
 	accessKey string,
 	secretKey string,
@@ -90,54 +165,17 @@ func NewAwsConfig(
 	skipSSLVerification bool,
 ) *aws.Config {
 
-	sess := session.New()
-
-	creds := credentials.NewChainCredentials(
-		[]credentials.Provider{
-			&credentials.StaticProvider{
-				Value: credentials.Value{
-					AccessKeyID:     accessKey,
-					SecretAccessKey: secretKey,
-					SessionToken:    sessionToken,
-					ProviderName:    "Statically Defined",
-				},
-			},
-			&ec2rolecreds.EC2RoleProvider{
-				Client: ec2metadata.New(sess),
-			},
-			&credentials.StaticProvider{
-				Value: credentials.Value{},
-			},
-		})
-
-	if len(regionName) == 0 {
-		regionName = "us-east-1"
+	b := AwsConfigBuilder{
+		AccessKey:           accessKey,
+		SecretKey:           secretKey,
+		SessionToken:        sessionToken,
+		RegionName:          regionName,
+		Endpoint:            endpoint,
+		DisableSSL:          disableSSL,
+		SkipSSLVerification: skipSSLVerification,
 	}
 
-	var httpClient *http.Client
-	if skipSSLVerification {
-		httpClient = &http.Client{Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}}
-	} else {
-		httpClient = http.DefaultClient
-	}
-
-	awsConfig := &aws.Config{
-		Region:           aws.String(regionName),
-		Credentials:      creds,
-		S3ForcePathStyle: aws.Bool(true),
-		MaxRetries:       aws.Int(maxRetries),
-		DisableSSL:       aws.Bool(disableSSL),
-		HTTPClient:       httpClient,
-	}
-
-	if len(endpoint) != 0 {
-		endpoint := fmt.Sprintf("%s", endpoint)
-		awsConfig.Endpoint = &endpoint
-	}
-
-	return awsConfig
+	return b.Build()
 }
 
 func (client *s3client) BucketFiles(bucketName string, prefixHint string) ([]string, error) {


### PR DESCRIPTION
## Description

* Allows EC2Role creds for Concourse running in AWS

_Note:_ It looks like `go fmt` modified a few extra lines.

## Test Output

```
Ran 0 of 29 Specs in 0.012 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 29 Skipped PASS
Running Suite: Out Suite
========================
Random Seed: 1522091803
Will run 20 of 20 specs

••••••••••••••••••••
Ran 20 of 20 Specs in 0.015 seconds
SUCCESS! -- 20 Passed | 0 Failed | 0 Pending | 0 Skipped PASS
Running Suite: Versions Suite
=============================
Random Seed: 1522091803
Will run 22 of 22 specs

••••••••••••••••••••••
Ran 22 of 22 Specs in 0.007 seconds
SUCCESS! -- 22 Passed | 0 Failed | 0 Pending | 0 Skipped PASS
Removing intermediate container 462b74b81892
 ---> 2e399e4a2b5e
Step 25/25 : FROM resource
 ---> e6120f6a912d
Successfully built e6120f6a912d
Successfully tagged concourse/s3-resource:test
```

Let me see if I can get a test bucket going that I can try out.