### PR TITLE
in: fix #95 add an option to not download the s3 file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ version numbers.
 
 * `skip_ssl_verification`: *Optional.* Skip SSL verification for S3 endpoint. Useful for S3 compatible providers using self-signed SSL certificates.
 
+* `skip_download`: *Optional.* Skip downloading object from S3. Useful only trigger the pipeline without using the object.
+
 * `server_side_encryption`: *Optional.* An encryption algorithm to use when
   storing objects in S3.
 

--- a/in/command.go
+++ b/in/command.go
@@ -98,30 +98,32 @@ func (command *Command) Run(destinationDir string, request Request) (Response, e
 			}
 		}
 	} else {
-		err = command.downloadFile(
-			request.Source.Bucket,
-			remotePath,
-			versionID,
-			destinationDir,
-			path.Base(remotePath),
-		)
-		if err != nil {
-			return Response{}, err
-		}
 
-		if request.Params.Unpack {
-			destinationPath := filepath.Join(destinationDir, path.Base(remotePath))
-			mime := archiveMimetype(destinationPath)
-			if mime == "" {
-				return Response{}, fmt.Errorf("not an archive: %s", destinationPath)
-			}
-
-			err = extractArchive(mime, destinationPath)
+		if !request.Source.SkipDownload {
+			err = command.downloadFile(
+				request.Source.Bucket,
+				remotePath,
+				versionID,
+				destinationDir,
+				path.Base(remotePath),
+			)
 			if err != nil {
 				return Response{}, err
 			}
-		}
 
+			if request.Params.Unpack {
+				destinationPath := filepath.Join(destinationDir, path.Base(remotePath))
+				mime := archiveMimetype(destinationPath)
+				if mime == "" {
+					return Response{}, fmt.Errorf("not an archive: %s", destinationPath)
+				}
+
+				err = extractArchive(mime, destinationPath)
+				if err != nil {
+					return Response{}, err
+				}
+			}
+		}
 		url = command.urlProvider.GetURL(request, remotePath)
 		if err = command.writeURLFile(destinationDir, url); err != nil {
 			return Response{}, err

--- a/in/command_test.go
+++ b/in/command_test.go
@@ -79,6 +79,18 @@ var _ = Describe("In Command", func() {
 			})
 		})
 
+		Context("when configured to skip download", func() {
+			BeforeEach(func() {
+				request.Source.SkipDownload = true
+			})
+
+			It("doesn't download the file", func() {
+				_, err := command.Run(destDir, request)
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(s3client.DownloadFileCallCount()).Should(Equal(0))
+			})
+		})
+
 		Context("when there is an existing version in the request", func() {
 			BeforeEach(func() {
 				request.Version.Path = "files/a-file-1.3"

--- a/models.go
+++ b/models.go
@@ -16,6 +16,7 @@ type Source struct {
 	SSEKMSKeyId          string `json:"sse_kms_key_id"`
 	UseV2Signing         bool   `json:"use_v2_signing"`
 	SkipSSLVerification  bool   `json:"skip_ssl_verification"`
+	SkipDownload         bool   `json:"skip_download"`
 	InitialVersion       string `json:"initial_version"`
 	InitialPath          string `json:"initial_path"`
 	InitialContentText   string `json:"initial_content_text"`


### PR DESCRIPTION
Adding skip_download param on the resource to not download file on
resource get.

Useful only trigger the pipeline without using the object.