### PR TITLE
in: add skip_download override param by get

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ Places the following files in the destination:
 
 #### Parameters
 
-* `unpack`: *Optional.* If true and the file is an archive (tar, gzipped tar, other gzipped file, or zip), unpack the file. Gzipped tarballs will be both ungzipped and untarred. It is ignored when `get` is running on the initial version.
+* `skip_download`: *Optional.* Skip downloading object from S3. Same parameter as source configuration but used to define/override by get. Value need to be a true/false string.
 
+* `unpack`: *Optional.* If true and the file is an archive (tar, gzipped tar, other gzipped file, or zip), unpack the file. Gzipped tarballs will be both ungzipped and untarred. It is ignored when `get` is running on the initial version.
 
 ### `out`: Upload an object to the bucket.
 

--- a/in/command.go
+++ b/in/command.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 
 	"github.com/concourse/s3-resource"
 	"github.com/concourse/s3-resource/versions"
@@ -56,6 +57,7 @@ func (command *Command) Run(destinationDir string, request Request) (Response, e
 	var versionID string
 	var url string
 	var isInitialVersion bool
+	var skipDownload bool
 
 	if request.Source.Regexp != "" {
 		if request.Version.Path == "" {
@@ -99,7 +101,16 @@ func (command *Command) Run(destinationDir string, request Request) (Response, e
 		}
 	} else {
 
-		if !request.Source.SkipDownload {
+		if request.Params.SkipDownload != "" {
+			skipDownload, err = strconv.ParseBool(request.Params.SkipDownload)
+			if err != nil {
+				return Response{}, fmt.Errorf("skip_download defined but invalid value: %s", request.Params.SkipDownload)
+			}
+		} else {
+			skipDownload = request.Source.SkipDownload
+		}
+
+		if !skipDownload {
 			err = command.downloadFile(
 				request.Source.Bucket,
 				remotePath,

--- a/in/command_test.go
+++ b/in/command_test.go
@@ -79,7 +79,7 @@ var _ = Describe("In Command", func() {
 			})
 		})
 
-		Context("when configured to skip download", func() {
+		Context("when configured globaly to skip download", func() {
 			BeforeEach(func() {
 				request.Source.SkipDownload = true
 			})
@@ -88,6 +88,43 @@ var _ = Describe("In Command", func() {
 				_, err := command.Run(destDir, request)
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(s3client.DownloadFileCallCount()).Should(Equal(0))
+			})
+		})
+
+		Context("when configured localy to skip download", func() {
+			BeforeEach(func() {
+				request.Params.SkipDownload = "true"
+			})
+
+			It("doesn't download the file", func() {
+				_, err := command.Run(destDir, request)
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(s3client.DownloadFileCallCount()).Should(Equal(0))
+			})
+		})
+
+		Context("when override localy to not skip download", func() {
+			BeforeEach(func() {
+				request.Source.SkipDownload = true
+				request.Params.SkipDownload = "false"
+			})
+
+			It("doesn't download the file", func() {
+				_, err := command.Run(destDir, request)
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(s3client.DownloadFileCallCount()).Should(Equal(1))
+			})
+		})
+
+		Context("when override using a wrong value for local skipdownload", func() {
+			BeforeEach(func() {
+				request.Params.SkipDownload = "foo"
+			})
+
+			It("doesn't download the file", func() {
+				_, err := command.Run(destDir, request)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("skip_download defined but invalid value"))
 			})
 		})
 

--- a/in/models.go
+++ b/in/models.go
@@ -9,7 +9,8 @@ type Request struct {
 }
 
 type Params struct {
-	Unpack bool `json:"unpack"`
+	Unpack       bool   `json:"unpack"`
+	SkipDownload string `json:"skip_download"`
 }
 
 type Response struct {


### PR DESCRIPTION
skip_download can be defined globaly in the source configuration but for
specific usecase we might need to apply or override it only on few gets.

skip_download have been added on get params.

Defined as string in order to have 3 stats : 
  * not defined : that means we keep the global value
  * false : force to false/download for the specific get
  * true : force to true/skipdownload for the specific get