### PR TITLE
Fixing a bug that prevents resource from working with Dell EMC ECS object store

### DIFF
--- a/s3client.go
+++ b/s3client.go
@@ -386,10 +386,12 @@ func (client *s3client) getVersionedBucketContents(bucketName string, prefix str
 
 		params := &s3.ListObjectVersionsInput{
 			Bucket:    aws.String(bucketName),
-			KeyMarker: aws.String(keyMarker),
 			Prefix:    aws.String(prefix),
 		}
 
+		if keyMarker != "" {
+			params.KeyMarker = aws.String(keyMarker)
+		}
 		if versionMarker != "" {
 			params.VersionIdMarker = aws.String(versionMarker)
 		}


### PR DESCRIPTION
Currently, this resource's check function throws an error when working with ECS.  ECS is an S3-compliant object store from Dell EMC (more info [here](https://www.dellemc.com/en-us/storage/ecs/index.htm#collapse)).  Check throws the following error:

```bash
resource script '/opt/resource/check []' failed: exit status 1

stderr:
[31merror finding versions: InvalidArgument: Invalid Argument
	status code: 400, request id: 0ac6640d:1635ec685dc:834e8:55, host id: 

[0m
```

This is a simple fix to eliminate that error when interacting with ECS buckets.