### PR TITLE
Allow (redacted) source to be output to the filesystem, if desired

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ version numbers.
 
 * `use_v2_signing`: *Optional.* Use signature v2 signing, useful for S3 compatible providers that do not support v4.
 
+* `debug`: *Optional.* If true, the file `$TMPDIR/{check,in,out}-request` will be generated with the values passed to the script, with sensitive information redacted.
+
 ### File Names
 
 One of the following two options must be specified:

--- a/models.go
+++ b/models.go
@@ -21,6 +21,7 @@ type Source struct {
 	InitialPath          string `json:"initial_path"`
 	InitialContentText   string `json:"initial_content_text"`
 	InitialContentBinary string `json:"initial_content_binary"`
+	Debug                bool   `json:"debug"`
 }
 
 func (source Source) IsValid() (bool, string) {

--- a/utils.go
+++ b/utils.go
@@ -7,6 +7,8 @@ import (
 	"github.com/mitchellh/colorstring"
 )
 
+const redacted = "redacted"
+
 func Fatal(doing string, err error) {
 	Sayf(colorstring.Color("[red]error %s: %s\n"), doing, err)
 	os.Exit(1)
@@ -14,4 +16,14 @@ func Fatal(doing string, err error) {
 
 func Sayf(message string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, message, args...)
+}
+
+func RedactSource(src Source) Source {
+	redactedSource := src
+
+	redactedSource.AccessKeyID = redacted
+	redactedSource.SecretAccessKey = redacted
+	redactedSource.SSEKMSKeyId = redacted
+
+	return redactedSource
 }


### PR DESCRIPTION
I've been asked multiple times in the past if there was a way to view what the resource was passed via `stdin`. This PR takes a stab at that by introducing an optional `debug` source option.