### PR TITLE
Enable to select whether to do multipart upload or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ version numbers.
 
 * `use_v2_signing`: *Optional.* Use signature v2 signing, useful for S3 compatible providers that do not support v4.
 
+* `disable_multipart`: *Optional.* Disable Multipart Upload. useful for S3 compatible providers that do not support multipart upload.
+
 ### File Names
 
 One of the following two options must be specified:

--- a/models.go
+++ b/models.go
@@ -21,6 +21,7 @@ type Source struct {
 	InitialPath          string `json:"initial_path"`
 	InitialContentText   string `json:"initial_content_text"`
 	InitialContentBinary string `json:"initial_content_binary"`
+	DisableMultipart     bool   `json:"disable_multipart"`
 }
 
 func (source Source) IsValid() (bool, string) {

--- a/out/command.go
+++ b/out/command.go
@@ -64,6 +64,7 @@ func (command *Command) Run(sourceDir string, request Request) (Response, error)
 	options.ContentType = request.Params.ContentType
 	options.ServerSideEncryption = request.Source.ServerSideEncryption
 	options.KmsKeyId = request.Source.SSEKMSKeyId
+	options.DisableMultipart = request.Source.DisableMultipart
 
 	versionID, err := command.s3client.UploadFile(
 		bucketName,

--- a/s3client.go
+++ b/s3client.go
@@ -50,6 +50,7 @@ type UploadFileOptions struct {
 	ServerSideEncryption string
 	KmsKeyId             string
 	ContentType          string
+	DisableMultipart     bool
 }
 
 func NewUploadFileOptions() UploadFileOptions {
@@ -184,15 +185,21 @@ func (client *s3client) UploadFile(bucketName string, remotePath string, localPa
 	}
 
 	defer localFile.Close()
-	
+
 	// Automatically adjust partsize for larger files.
 	fSize := stat.Size()
-	if fSize > int64(uploader.MaxUploadParts) * uploader.PartSize {
-		partSize := fSize / int64(uploader.MaxUploadParts)
-		if fSize % int64(uploader.MaxUploadParts) != 0 {
-			partSize++
+	if !options.DisableMultipart {
+		if fSize > int64(uploader.MaxUploadParts)*uploader.PartSize {
+			partSize := fSize / int64(uploader.MaxUploadParts)
+			if fSize%int64(uploader.MaxUploadParts) != 0 {
+				partSize++
+			}
+			uploader.PartSize = partSize
 		}
-		uploader.PartSize = partSize
+	} else {
+		uploader.MaxUploadParts = 1
+		uploader.Concurrency = 1
+		uploader.PartSize = fSize + 1
 	}
 
 	progress := client.newProgressBar(fSize)
@@ -385,8 +392,8 @@ func (client *s3client) getVersionedBucketContents(bucketName string, prefix str
 	for {
 
 		params := &s3.ListObjectVersionsInput{
-			Bucket:    aws.String(bucketName),
-			Prefix:    aws.String(prefix),
+			Bucket: aws.String(bucketName),
+			Prefix: aws.String(prefix),
 		}
 
 		if keyMarker != "" {


### PR DESCRIPTION
Hi.

I enable to prevent multipart upload.
Users who use object storage which does not support multipart upload will be helpful.