### PR TITLE
Fix upload part size when `disable_multipart` is set

### DIFF
--- a/s3client.go
+++ b/s3client.go
@@ -200,6 +200,9 @@ func (client *s3client) UploadFile(bucketName string, remotePath string, localPa
 		uploader.MaxUploadParts = 1
 		uploader.Concurrency = 1
 		uploader.PartSize = fSize + 1
+		if fSize <= s3manager.MinUploadPartSize {
+			uploader.PartSize = s3manager.MinUploadPartSize
+		}
 	}
 
 	progress := client.newProgressBar(fSize)


### PR DESCRIPTION
An error occurred in my pipeline using s3-resource.

```
0 B / 3.46 MB [------------------------------------------------------] 0.00 % 0serror running command: ConfigError: part size must be at least 5242880 bytes
```

I set `disable_mutipart: true` in source configuration.

Before, when `deisalbe_multipart` is set, upload part size is file size + 1.
https://github.com/concourse/s3-resource/blob/84741092da864119fa7bc64654804c880de4c34c/s3client.go#L202

S3 compatible provider has a minimum size of the upload part.
[Amazon S3 Multipart Upload Limits \- Amazon Simple Storage Service](https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html)

So, if the file size is smaller than this, the upload fails.
I fixed it.

Sorry, I can't write the test for these changes.
But I confirmed that this patch works for a pipeline that has errors.
```
3.46 MB / 3.46 MB [======================================] 100.00 % 6.50 MB/s 0s
```