### PR TITLE
Optionally download tags when getting object

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ The objects in the bucket (e.g. `"arn:aws:s3:::your-bucket/*"`):
 * `s3:PutObject`
 * `s3:PutObjectAcl`
 * `s3:GetObject`
+* `s3:GetObjectTagging` (if using the `download_tags` option)
 
 ### Versioned Buckets
 
@@ -200,6 +201,7 @@ The bucket itself (e.g. `"arn:aws:s3:::your-bucket"`):
 The objects in the bucket (e.g. `"arn:aws:s3:::your-bucket/*"`):
 * `s3:GetObjectVersion`
 * `s3:PutObjectVersionAcl`
+* `s3:GetObjectVersionTagging` (if using the `download_tags` option)
 
 ## Developing on this resource
 
@@ -255,6 +257,10 @@ docker build . -t s3-resource -f dockerfiles/ubuntu/Dockerfile \
   --build-arg S3_TESTING_REGION="us-east-1" \
   --build-arg S3_ENDPOINT="https://s3.amazonaws.com"
 ```
+
+##### Required IAM permissions
+
+In addition to the required permissions above, the `s3:PutObjectTagging` permission is required to run integration tests.
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -103,11 +103,15 @@ Places the following files in the destination:
 
 * `version`: The version identified in the file name.
 
+* `tags.json`: The object's tags represented as a JSON object. Only written if `download_tags` is set to true.
+
 #### Parameters
 
-* `skip_download`: *Optional.* Skip downloading object from S3. Same parameter as source configuration but used to define/override by get. Value need to be a true/false string.
+* `skip_download`: *Optional.* Skip downloading object from S3. Same parameter as source configuration but used to define/override by get. Value needs to be a true/false string.
 
 * `unpack`: *Optional.* If true and the file is an archive (tar, gzipped tar, other gzipped file, or zip), unpack the file. Gzipped tarballs will be both ungzipped and untarred. It is ignored when `get` is running on the initial version.
+
+* `download_tags`: *Optional.* Write object tags to `tags.json`. Value needs to be a true/false string.
 
 ### `out`: Upload an object to the bucket.
 

--- a/fakes/fake_s3client.go
+++ b/fakes/fake_s3client.go
@@ -8,131 +8,152 @@ import (
 )
 
 type FakeS3Client struct {
-	BucketFilesStub        func(bucketName string, prefixHint string) ([]string, error)
-	bucketFilesMutex       sync.RWMutex
-	bucketFilesArgsForCall []struct {
-		bucketName string
-		prefixHint string
-	}
-	bucketFilesReturns struct {
-		result1 []string
-		result2 error
-	}
-	BucketFileVersionsStub        func(bucketName string, remotePath string) ([]string, error)
+	BucketFileVersionsStub        func(string, string) ([]string, error)
 	bucketFileVersionsMutex       sync.RWMutex
 	bucketFileVersionsArgsForCall []struct {
-		bucketName string
-		remotePath string
+		arg1 string
+		arg2 string
 	}
 	bucketFileVersionsReturns struct {
 		result1 []string
 		result2 error
 	}
-	UploadFileStub        func(bucketName string, remotePath string, localPath string, options s3resource.UploadFileOptions) (string, error)
+	bucketFileVersionsReturnsOnCall map[int]struct {
+		result1 []string
+		result2 error
+	}
+	BucketFilesStub        func(string, string) ([]string, error)
+	bucketFilesMutex       sync.RWMutex
+	bucketFilesArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	bucketFilesReturns struct {
+		result1 []string
+		result2 error
+	}
+	bucketFilesReturnsOnCall map[int]struct {
+		result1 []string
+		result2 error
+	}
+	DeleteFileStub        func(string, string) error
+	deleteFileMutex       sync.RWMutex
+	deleteFileArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	deleteFileReturns struct {
+		result1 error
+	}
+	deleteFileReturnsOnCall map[int]struct {
+		result1 error
+	}
+	DeleteVersionedFileStub        func(string, string, string) error
+	deleteVersionedFileMutex       sync.RWMutex
+	deleteVersionedFileArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}
+	deleteVersionedFileReturns struct {
+		result1 error
+	}
+	deleteVersionedFileReturnsOnCall map[int]struct {
+		result1 error
+	}
+	DownloadFileStub        func(string, string, string, string) error
+	downloadFileMutex       sync.RWMutex
+	downloadFileArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 string
+	}
+	downloadFileReturns struct {
+		result1 error
+	}
+	downloadFileReturnsOnCall map[int]struct {
+		result1 error
+	}
+	DownloadTagsStub        func(string, string, string, string) error
+	downloadTagsMutex       sync.RWMutex
+	downloadTagsArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 string
+	}
+	downloadTagsReturns struct {
+		result1 error
+	}
+	downloadTagsReturnsOnCall map[int]struct {
+		result1 error
+	}
+	SetTagsStub        func(string, string, string, map[string]string) error
+	setTagsMutex       sync.RWMutex
+	setTagsArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 map[string]string
+	}
+	setTagsReturns struct {
+		result1 error
+	}
+	setTagsReturnsOnCall map[int]struct {
+		result1 error
+	}
+	URLStub        func(string, string, bool, string) string
+	uRLMutex       sync.RWMutex
+	uRLArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 bool
+		arg4 string
+	}
+	uRLReturns struct {
+		result1 string
+	}
+	uRLReturnsOnCall map[int]struct {
+		result1 string
+	}
+	UploadFileStub        func(string, string, string, s3resource.UploadFileOptions) (string, error)
 	uploadFileMutex       sync.RWMutex
 	uploadFileArgsForCall []struct {
-		bucketName string
-		remotePath string
-		localPath  string
-		options    s3resource.UploadFileOptions
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 s3resource.UploadFileOptions
 	}
 	uploadFileReturns struct {
 		result1 string
 		result2 error
 	}
-	DownloadFileStub        func(bucketName string, remotePath string, versionID string, localPath string) error
-	downloadFileMutex       sync.RWMutex
-	downloadFileArgsForCall []struct {
-		bucketName string
-		remotePath string
-		versionID  string
-		localPath  string
-	}
-	downloadFileReturns struct {
-		result1 error
-	}
-	DeleteFileStub        func(bucketName string, remotePath string) error
-	deleteFileMutex       sync.RWMutex
-	deleteFileArgsForCall []struct {
-		bucketName string
-		remotePath string
-	}
-	deleteFileReturns struct {
-		result1 error
-	}
-	DeleteVersionedFileStub        func(bucketName string, remotePath string, versionID string) error
-	deleteVersionedFileMutex       sync.RWMutex
-	deleteVersionedFileArgsForCall []struct {
-		bucketName string
-		remotePath string
-		versionID  string
-	}
-	deleteVersionedFileReturns struct {
-		result1 error
-	}
-	URLStub        func(bucketName string, remotePath string, private bool, versionID string) string
-	uRLMutex       sync.RWMutex
-	uRLArgsForCall []struct {
-		bucketName string
-		remotePath string
-		private    bool
-		versionID  string
-	}
-	uRLReturns struct {
+	uploadFileReturnsOnCall map[int]struct {
 		result1 string
+		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeS3Client) BucketFiles(bucketName string, prefixHint string) ([]string, error) {
-	fake.bucketFilesMutex.Lock()
-	fake.bucketFilesArgsForCall = append(fake.bucketFilesArgsForCall, struct {
-		bucketName string
-		prefixHint string
-	}{bucketName, prefixHint})
-	fake.recordInvocation("BucketFiles", []interface{}{bucketName, prefixHint})
-	fake.bucketFilesMutex.Unlock()
-	if fake.BucketFilesStub != nil {
-		return fake.BucketFilesStub(bucketName, prefixHint)
-	} else {
-		return fake.bucketFilesReturns.result1, fake.bucketFilesReturns.result2
-	}
-}
-
-func (fake *FakeS3Client) BucketFilesCallCount() int {
-	fake.bucketFilesMutex.RLock()
-	defer fake.bucketFilesMutex.RUnlock()
-	return len(fake.bucketFilesArgsForCall)
-}
-
-func (fake *FakeS3Client) BucketFilesArgsForCall(i int) (string, string) {
-	fake.bucketFilesMutex.RLock()
-	defer fake.bucketFilesMutex.RUnlock()
-	return fake.bucketFilesArgsForCall[i].bucketName, fake.bucketFilesArgsForCall[i].prefixHint
-}
-
-func (fake *FakeS3Client) BucketFilesReturns(result1 []string, result2 error) {
-	fake.BucketFilesStub = nil
-	fake.bucketFilesReturns = struct {
-		result1 []string
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeS3Client) BucketFileVersions(bucketName string, remotePath string) ([]string, error) {
+func (fake *FakeS3Client) BucketFileVersions(arg1 string, arg2 string) ([]string, error) {
 	fake.bucketFileVersionsMutex.Lock()
+	ret, specificReturn := fake.bucketFileVersionsReturnsOnCall[len(fake.bucketFileVersionsArgsForCall)]
 	fake.bucketFileVersionsArgsForCall = append(fake.bucketFileVersionsArgsForCall, struct {
-		bucketName string
-		remotePath string
-	}{bucketName, remotePath})
-	fake.recordInvocation("BucketFileVersions", []interface{}{bucketName, remotePath})
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("BucketFileVersions", []interface{}{arg1, arg2})
 	fake.bucketFileVersionsMutex.Unlock()
 	if fake.BucketFileVersionsStub != nil {
-		return fake.BucketFileVersionsStub(bucketName, remotePath)
-	} else {
-		return fake.bucketFileVersionsReturns.result1, fake.bucketFileVersionsReturns.result2
+		return fake.BucketFileVersionsStub(arg1, arg2)
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.bucketFileVersionsReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeS3Client) BucketFileVersionsCallCount() int {
@@ -141,13 +162,22 @@ func (fake *FakeS3Client) BucketFileVersionsCallCount() int {
 	return len(fake.bucketFileVersionsArgsForCall)
 }
 
+func (fake *FakeS3Client) BucketFileVersionsCalls(stub func(string, string) ([]string, error)) {
+	fake.bucketFileVersionsMutex.Lock()
+	defer fake.bucketFileVersionsMutex.Unlock()
+	fake.BucketFileVersionsStub = stub
+}
+
 func (fake *FakeS3Client) BucketFileVersionsArgsForCall(i int) (string, string) {
 	fake.bucketFileVersionsMutex.RLock()
 	defer fake.bucketFileVersionsMutex.RUnlock()
-	return fake.bucketFileVersionsArgsForCall[i].bucketName, fake.bucketFileVersionsArgsForCall[i].remotePath
+	argsForCall := fake.bucketFileVersionsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeS3Client) BucketFileVersionsReturns(result1 []string, result2 error) {
+	fake.bucketFileVersionsMutex.Lock()
+	defer fake.bucketFileVersionsMutex.Unlock()
 	fake.BucketFileVersionsStub = nil
 	fake.bucketFileVersionsReturns = struct {
 		result1 []string
@@ -155,92 +185,103 @@ func (fake *FakeS3Client) BucketFileVersionsReturns(result1 []string, result2 er
 	}{result1, result2}
 }
 
-func (fake *FakeS3Client) UploadFile(bucketName string, remotePath string, localPath string, options s3resource.UploadFileOptions) (string, error) {
-	fake.uploadFileMutex.Lock()
-	fake.uploadFileArgsForCall = append(fake.uploadFileArgsForCall, struct {
-		bucketName string
-		remotePath string
-		localPath  string
-		options    s3resource.UploadFileOptions
-	}{bucketName, remotePath, localPath, options})
-	fake.recordInvocation("UploadFile", []interface{}{bucketName, remotePath, localPath, options})
-	fake.uploadFileMutex.Unlock()
-	if fake.UploadFileStub != nil {
-		return fake.UploadFileStub(bucketName, remotePath, localPath, options)
-	} else {
-		return fake.uploadFileReturns.result1, fake.uploadFileReturns.result2
+func (fake *FakeS3Client) BucketFileVersionsReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.bucketFileVersionsMutex.Lock()
+	defer fake.bucketFileVersionsMutex.Unlock()
+	fake.BucketFileVersionsStub = nil
+	if fake.bucketFileVersionsReturnsOnCall == nil {
+		fake.bucketFileVersionsReturnsOnCall = make(map[int]struct {
+			result1 []string
+			result2 error
+		})
 	}
-}
-
-func (fake *FakeS3Client) UploadFileCallCount() int {
-	fake.uploadFileMutex.RLock()
-	defer fake.uploadFileMutex.RUnlock()
-	return len(fake.uploadFileArgsForCall)
-}
-
-func (fake *FakeS3Client) UploadFileArgsForCall(i int) (string, string, string, s3resource.UploadFileOptions) {
-	fake.uploadFileMutex.RLock()
-	defer fake.uploadFileMutex.RUnlock()
-	return fake.uploadFileArgsForCall[i].bucketName, fake.uploadFileArgsForCall[i].remotePath, fake.uploadFileArgsForCall[i].localPath, fake.uploadFileArgsForCall[i].options
-}
-
-func (fake *FakeS3Client) UploadFileReturns(result1 string, result2 error) {
-	fake.UploadFileStub = nil
-	fake.uploadFileReturns = struct {
-		result1 string
+	fake.bucketFileVersionsReturnsOnCall[i] = struct {
+		result1 []string
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeS3Client) DownloadFile(bucketName string, remotePath string, versionID string, localPath string) error {
-	fake.downloadFileMutex.Lock()
-	fake.downloadFileArgsForCall = append(fake.downloadFileArgsForCall, struct {
-		bucketName string
-		remotePath string
-		versionID  string
-		localPath  string
-	}{bucketName, remotePath, versionID, localPath})
-	fake.recordInvocation("DownloadFile", []interface{}{bucketName, remotePath, versionID, localPath})
-	fake.downloadFileMutex.Unlock()
-	if fake.DownloadFileStub != nil {
-		return fake.DownloadFileStub(bucketName, remotePath, versionID, localPath)
-	} else {
-		return fake.downloadFileReturns.result1
+func (fake *FakeS3Client) BucketFiles(arg1 string, arg2 string) ([]string, error) {
+	fake.bucketFilesMutex.Lock()
+	ret, specificReturn := fake.bucketFilesReturnsOnCall[len(fake.bucketFilesArgsForCall)]
+	fake.bucketFilesArgsForCall = append(fake.bucketFilesArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("BucketFiles", []interface{}{arg1, arg2})
+	fake.bucketFilesMutex.Unlock()
+	if fake.BucketFilesStub != nil {
+		return fake.BucketFilesStub(arg1, arg2)
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.bucketFilesReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeS3Client) DownloadFileCallCount() int {
-	fake.downloadFileMutex.RLock()
-	defer fake.downloadFileMutex.RUnlock()
-	return len(fake.downloadFileArgsForCall)
+func (fake *FakeS3Client) BucketFilesCallCount() int {
+	fake.bucketFilesMutex.RLock()
+	defer fake.bucketFilesMutex.RUnlock()
+	return len(fake.bucketFilesArgsForCall)
 }
 
-func (fake *FakeS3Client) DownloadFileArgsForCall(i int) (string, string, string, string) {
-	fake.downloadFileMutex.RLock()
-	defer fake.downloadFileMutex.RUnlock()
-	return fake.downloadFileArgsForCall[i].bucketName, fake.downloadFileArgsForCall[i].remotePath, fake.downloadFileArgsForCall[i].versionID, fake.downloadFileArgsForCall[i].localPath
+func (fake *FakeS3Client) BucketFilesCalls(stub func(string, string) ([]string, error)) {
+	fake.bucketFilesMutex.Lock()
+	defer fake.bucketFilesMutex.Unlock()
+	fake.BucketFilesStub = stub
 }
 
-func (fake *FakeS3Client) DownloadFileReturns(result1 error) {
-	fake.DownloadFileStub = nil
-	fake.downloadFileReturns = struct {
-		result1 error
-	}{result1}
+func (fake *FakeS3Client) BucketFilesArgsForCall(i int) (string, string) {
+	fake.bucketFilesMutex.RLock()
+	defer fake.bucketFilesMutex.RUnlock()
+	argsForCall := fake.bucketFilesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeS3Client) DeleteFile(bucketName string, remotePath string) error {
+func (fake *FakeS3Client) BucketFilesReturns(result1 []string, result2 error) {
+	fake.bucketFilesMutex.Lock()
+	defer fake.bucketFilesMutex.Unlock()
+	fake.BucketFilesStub = nil
+	fake.bucketFilesReturns = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeS3Client) BucketFilesReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.bucketFilesMutex.Lock()
+	defer fake.bucketFilesMutex.Unlock()
+	fake.BucketFilesStub = nil
+	if fake.bucketFilesReturnsOnCall == nil {
+		fake.bucketFilesReturnsOnCall = make(map[int]struct {
+			result1 []string
+			result2 error
+		})
+	}
+	fake.bucketFilesReturnsOnCall[i] = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeS3Client) DeleteFile(arg1 string, arg2 string) error {
 	fake.deleteFileMutex.Lock()
+	ret, specificReturn := fake.deleteFileReturnsOnCall[len(fake.deleteFileArgsForCall)]
 	fake.deleteFileArgsForCall = append(fake.deleteFileArgsForCall, struct {
-		bucketName string
-		remotePath string
-	}{bucketName, remotePath})
-	fake.recordInvocation("DeleteFile", []interface{}{bucketName, remotePath})
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("DeleteFile", []interface{}{arg1, arg2})
 	fake.deleteFileMutex.Unlock()
 	if fake.DeleteFileStub != nil {
-		return fake.DeleteFileStub(bucketName, remotePath)
-	} else {
-		return fake.deleteFileReturns.result1
+		return fake.DeleteFileStub(arg1, arg2)
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.deleteFileReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeS3Client) DeleteFileCallCount() int {
@@ -249,33 +290,60 @@ func (fake *FakeS3Client) DeleteFileCallCount() int {
 	return len(fake.deleteFileArgsForCall)
 }
 
+func (fake *FakeS3Client) DeleteFileCalls(stub func(string, string) error) {
+	fake.deleteFileMutex.Lock()
+	defer fake.deleteFileMutex.Unlock()
+	fake.DeleteFileStub = stub
+}
+
 func (fake *FakeS3Client) DeleteFileArgsForCall(i int) (string, string) {
 	fake.deleteFileMutex.RLock()
 	defer fake.deleteFileMutex.RUnlock()
-	return fake.deleteFileArgsForCall[i].bucketName, fake.deleteFileArgsForCall[i].remotePath
+	argsForCall := fake.deleteFileArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeS3Client) DeleteFileReturns(result1 error) {
+	fake.deleteFileMutex.Lock()
+	defer fake.deleteFileMutex.Unlock()
 	fake.DeleteFileStub = nil
 	fake.deleteFileReturns = struct {
 		result1 error
 	}{result1}
 }
 
-func (fake *FakeS3Client) DeleteVersionedFile(bucketName string, remotePath string, versionID string) error {
+func (fake *FakeS3Client) DeleteFileReturnsOnCall(i int, result1 error) {
+	fake.deleteFileMutex.Lock()
+	defer fake.deleteFileMutex.Unlock()
+	fake.DeleteFileStub = nil
+	if fake.deleteFileReturnsOnCall == nil {
+		fake.deleteFileReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteFileReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeS3Client) DeleteVersionedFile(arg1 string, arg2 string, arg3 string) error {
 	fake.deleteVersionedFileMutex.Lock()
+	ret, specificReturn := fake.deleteVersionedFileReturnsOnCall[len(fake.deleteVersionedFileArgsForCall)]
 	fake.deleteVersionedFileArgsForCall = append(fake.deleteVersionedFileArgsForCall, struct {
-		bucketName string
-		remotePath string
-		versionID  string
-	}{bucketName, remotePath, versionID})
-	fake.recordInvocation("DeleteVersionedFile", []interface{}{bucketName, remotePath, versionID})
+		arg1 string
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("DeleteVersionedFile", []interface{}{arg1, arg2, arg3})
 	fake.deleteVersionedFileMutex.Unlock()
 	if fake.DeleteVersionedFileStub != nil {
-		return fake.DeleteVersionedFileStub(bucketName, remotePath, versionID)
-	} else {
-		return fake.deleteVersionedFileReturns.result1
+		return fake.DeleteVersionedFileStub(arg1, arg2, arg3)
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.deleteVersionedFileReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeS3Client) DeleteVersionedFileCallCount() int {
@@ -284,34 +352,250 @@ func (fake *FakeS3Client) DeleteVersionedFileCallCount() int {
 	return len(fake.deleteVersionedFileArgsForCall)
 }
 
+func (fake *FakeS3Client) DeleteVersionedFileCalls(stub func(string, string, string) error) {
+	fake.deleteVersionedFileMutex.Lock()
+	defer fake.deleteVersionedFileMutex.Unlock()
+	fake.DeleteVersionedFileStub = stub
+}
+
 func (fake *FakeS3Client) DeleteVersionedFileArgsForCall(i int) (string, string, string) {
 	fake.deleteVersionedFileMutex.RLock()
 	defer fake.deleteVersionedFileMutex.RUnlock()
-	return fake.deleteVersionedFileArgsForCall[i].bucketName, fake.deleteVersionedFileArgsForCall[i].remotePath, fake.deleteVersionedFileArgsForCall[i].versionID
+	argsForCall := fake.deleteVersionedFileArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeS3Client) DeleteVersionedFileReturns(result1 error) {
+	fake.deleteVersionedFileMutex.Lock()
+	defer fake.deleteVersionedFileMutex.Unlock()
 	fake.DeleteVersionedFileStub = nil
 	fake.deleteVersionedFileReturns = struct {
 		result1 error
 	}{result1}
 }
 
-func (fake *FakeS3Client) URL(bucketName string, remotePath string, private bool, versionID string) string {
+func (fake *FakeS3Client) DeleteVersionedFileReturnsOnCall(i int, result1 error) {
+	fake.deleteVersionedFileMutex.Lock()
+	defer fake.deleteVersionedFileMutex.Unlock()
+	fake.DeleteVersionedFileStub = nil
+	if fake.deleteVersionedFileReturnsOnCall == nil {
+		fake.deleteVersionedFileReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteVersionedFileReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeS3Client) DownloadFile(arg1 string, arg2 string, arg3 string, arg4 string) error {
+	fake.downloadFileMutex.Lock()
+	ret, specificReturn := fake.downloadFileReturnsOnCall[len(fake.downloadFileArgsForCall)]
+	fake.downloadFileArgsForCall = append(fake.downloadFileArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("DownloadFile", []interface{}{arg1, arg2, arg3, arg4})
+	fake.downloadFileMutex.Unlock()
+	if fake.DownloadFileStub != nil {
+		return fake.DownloadFileStub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.downloadFileReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeS3Client) DownloadFileCallCount() int {
+	fake.downloadFileMutex.RLock()
+	defer fake.downloadFileMutex.RUnlock()
+	return len(fake.downloadFileArgsForCall)
+}
+
+func (fake *FakeS3Client) DownloadFileCalls(stub func(string, string, string, string) error) {
+	fake.downloadFileMutex.Lock()
+	defer fake.downloadFileMutex.Unlock()
+	fake.DownloadFileStub = stub
+}
+
+func (fake *FakeS3Client) DownloadFileArgsForCall(i int) (string, string, string, string) {
+	fake.downloadFileMutex.RLock()
+	defer fake.downloadFileMutex.RUnlock()
+	argsForCall := fake.downloadFileArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeS3Client) DownloadFileReturns(result1 error) {
+	fake.downloadFileMutex.Lock()
+	defer fake.downloadFileMutex.Unlock()
+	fake.DownloadFileStub = nil
+	fake.downloadFileReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeS3Client) DownloadFileReturnsOnCall(i int, result1 error) {
+	fake.downloadFileMutex.Lock()
+	defer fake.downloadFileMutex.Unlock()
+	fake.DownloadFileStub = nil
+	if fake.downloadFileReturnsOnCall == nil {
+		fake.downloadFileReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.downloadFileReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeS3Client) DownloadTags(arg1 string, arg2 string, arg3 string, arg4 string) error {
+	fake.downloadTagsMutex.Lock()
+	ret, specificReturn := fake.downloadTagsReturnsOnCall[len(fake.downloadTagsArgsForCall)]
+	fake.downloadTagsArgsForCall = append(fake.downloadTagsArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("DownloadTags", []interface{}{arg1, arg2, arg3, arg4})
+	fake.downloadTagsMutex.Unlock()
+	if fake.DownloadTagsStub != nil {
+		return fake.DownloadTagsStub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.downloadTagsReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeS3Client) DownloadTagsCallCount() int {
+	fake.downloadTagsMutex.RLock()
+	defer fake.downloadTagsMutex.RUnlock()
+	return len(fake.downloadTagsArgsForCall)
+}
+
+func (fake *FakeS3Client) DownloadTagsCalls(stub func(string, string, string, string) error) {
+	fake.downloadTagsMutex.Lock()
+	defer fake.downloadTagsMutex.Unlock()
+	fake.DownloadTagsStub = stub
+}
+
+func (fake *FakeS3Client) DownloadTagsArgsForCall(i int) (string, string, string, string) {
+	fake.downloadTagsMutex.RLock()
+	defer fake.downloadTagsMutex.RUnlock()
+	argsForCall := fake.downloadTagsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeS3Client) DownloadTagsReturns(result1 error) {
+	fake.downloadTagsMutex.Lock()
+	defer fake.downloadTagsMutex.Unlock()
+	fake.DownloadTagsStub = nil
+	fake.downloadTagsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeS3Client) DownloadTagsReturnsOnCall(i int, result1 error) {
+	fake.downloadTagsMutex.Lock()
+	defer fake.downloadTagsMutex.Unlock()
+	fake.DownloadTagsStub = nil
+	if fake.downloadTagsReturnsOnCall == nil {
+		fake.downloadTagsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.downloadTagsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeS3Client) SetTags(arg1 string, arg2 string, arg3 string, arg4 map[string]string) error {
+	fake.setTagsMutex.Lock()
+	ret, specificReturn := fake.setTagsReturnsOnCall[len(fake.setTagsArgsForCall)]
+	fake.setTagsArgsForCall = append(fake.setTagsArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 map[string]string
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("SetTags", []interface{}{arg1, arg2, arg3, arg4})
+	fake.setTagsMutex.Unlock()
+	if fake.SetTagsStub != nil {
+		return fake.SetTagsStub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.setTagsReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeS3Client) SetTagsCallCount() int {
+	fake.setTagsMutex.RLock()
+	defer fake.setTagsMutex.RUnlock()
+	return len(fake.setTagsArgsForCall)
+}
+
+func (fake *FakeS3Client) SetTagsCalls(stub func(string, string, string, map[string]string) error) {
+	fake.setTagsMutex.Lock()
+	defer fake.setTagsMutex.Unlock()
+	fake.SetTagsStub = stub
+}
+
+func (fake *FakeS3Client) SetTagsArgsForCall(i int) (string, string, string, map[string]string) {
+	fake.setTagsMutex.RLock()
+	defer fake.setTagsMutex.RUnlock()
+	argsForCall := fake.setTagsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeS3Client) SetTagsReturns(result1 error) {
+	fake.setTagsMutex.Lock()
+	defer fake.setTagsMutex.Unlock()
+	fake.SetTagsStub = nil
+	fake.setTagsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeS3Client) SetTagsReturnsOnCall(i int, result1 error) {
+	fake.setTagsMutex.Lock()
+	defer fake.setTagsMutex.Unlock()
+	fake.SetTagsStub = nil
+	if fake.setTagsReturnsOnCall == nil {
+		fake.setTagsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.setTagsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeS3Client) URL(arg1 string, arg2 string, arg3 bool, arg4 string) string {
 	fake.uRLMutex.Lock()
+	ret, specificReturn := fake.uRLReturnsOnCall[len(fake.uRLArgsForCall)]
 	fake.uRLArgsForCall = append(fake.uRLArgsForCall, struct {
-		bucketName string
-		remotePath string
-		private    bool
-		versionID  string
-	}{bucketName, remotePath, private, versionID})
-	fake.recordInvocation("URL", []interface{}{bucketName, remotePath, private, versionID})
+		arg1 string
+		arg2 string
+		arg3 bool
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("URL", []interface{}{arg1, arg2, arg3, arg4})
 	fake.uRLMutex.Unlock()
 	if fake.URLStub != nil {
-		return fake.URLStub(bucketName, remotePath, private, versionID)
-	} else {
-		return fake.uRLReturns.result1
+		return fake.URLStub(arg1, arg2, arg3, arg4)
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.uRLReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeS3Client) URLCallCount() int {
@@ -320,37 +604,134 @@ func (fake *FakeS3Client) URLCallCount() int {
 	return len(fake.uRLArgsForCall)
 }
 
+func (fake *FakeS3Client) URLCalls(stub func(string, string, bool, string) string) {
+	fake.uRLMutex.Lock()
+	defer fake.uRLMutex.Unlock()
+	fake.URLStub = stub
+}
+
 func (fake *FakeS3Client) URLArgsForCall(i int) (string, string, bool, string) {
 	fake.uRLMutex.RLock()
 	defer fake.uRLMutex.RUnlock()
-	return fake.uRLArgsForCall[i].bucketName, fake.uRLArgsForCall[i].remotePath, fake.uRLArgsForCall[i].private, fake.uRLArgsForCall[i].versionID
+	argsForCall := fake.uRLArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeS3Client) URLReturns(result1 string) {
+	fake.uRLMutex.Lock()
+	defer fake.uRLMutex.Unlock()
 	fake.URLStub = nil
 	fake.uRLReturns = struct {
 		result1 string
 	}{result1}
 }
 
+func (fake *FakeS3Client) URLReturnsOnCall(i int, result1 string) {
+	fake.uRLMutex.Lock()
+	defer fake.uRLMutex.Unlock()
+	fake.URLStub = nil
+	if fake.uRLReturnsOnCall == nil {
+		fake.uRLReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.uRLReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeS3Client) UploadFile(arg1 string, arg2 string, arg3 string, arg4 s3resource.UploadFileOptions) (string, error) {
+	fake.uploadFileMutex.Lock()
+	ret, specificReturn := fake.uploadFileReturnsOnCall[len(fake.uploadFileArgsForCall)]
+	fake.uploadFileArgsForCall = append(fake.uploadFileArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 s3resource.UploadFileOptions
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("UploadFile", []interface{}{arg1, arg2, arg3, arg4})
+	fake.uploadFileMutex.Unlock()
+	if fake.UploadFileStub != nil {
+		return fake.UploadFileStub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.uploadFileReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeS3Client) UploadFileCallCount() int {
+	fake.uploadFileMutex.RLock()
+	defer fake.uploadFileMutex.RUnlock()
+	return len(fake.uploadFileArgsForCall)
+}
+
+func (fake *FakeS3Client) UploadFileCalls(stub func(string, string, string, s3resource.UploadFileOptions) (string, error)) {
+	fake.uploadFileMutex.Lock()
+	defer fake.uploadFileMutex.Unlock()
+	fake.UploadFileStub = stub
+}
+
+func (fake *FakeS3Client) UploadFileArgsForCall(i int) (string, string, string, s3resource.UploadFileOptions) {
+	fake.uploadFileMutex.RLock()
+	defer fake.uploadFileMutex.RUnlock()
+	argsForCall := fake.uploadFileArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeS3Client) UploadFileReturns(result1 string, result2 error) {
+	fake.uploadFileMutex.Lock()
+	defer fake.uploadFileMutex.Unlock()
+	fake.UploadFileStub = nil
+	fake.uploadFileReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeS3Client) UploadFileReturnsOnCall(i int, result1 string, result2 error) {
+	fake.uploadFileMutex.Lock()
+	defer fake.uploadFileMutex.Unlock()
+	fake.UploadFileStub = nil
+	if fake.uploadFileReturnsOnCall == nil {
+		fake.uploadFileReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.uploadFileReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeS3Client) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.bucketFilesMutex.RLock()
-	defer fake.bucketFilesMutex.RUnlock()
 	fake.bucketFileVersionsMutex.RLock()
 	defer fake.bucketFileVersionsMutex.RUnlock()
-	fake.uploadFileMutex.RLock()
-	defer fake.uploadFileMutex.RUnlock()
-	fake.downloadFileMutex.RLock()
-	defer fake.downloadFileMutex.RUnlock()
+	fake.bucketFilesMutex.RLock()
+	defer fake.bucketFilesMutex.RUnlock()
 	fake.deleteFileMutex.RLock()
 	defer fake.deleteFileMutex.RUnlock()
 	fake.deleteVersionedFileMutex.RLock()
 	defer fake.deleteVersionedFileMutex.RUnlock()
+	fake.downloadFileMutex.RLock()
+	defer fake.downloadFileMutex.RUnlock()
+	fake.downloadTagsMutex.RLock()
+	defer fake.downloadTagsMutex.RUnlock()
+	fake.setTagsMutex.RLock()
+	defer fake.setTagsMutex.RUnlock()
 	fake.uRLMutex.RLock()
 	defer fake.uRLMutex.RUnlock()
-	return fake.invocations
+	fake.uploadFileMutex.RLock()
+	defer fake.uploadFileMutex.RUnlock()
+	copiedInvocations := map[string][][]interface{}{}
+	for key, value := range fake.invocations {
+		copiedInvocations[key] = value
+	}
+	return copiedInvocations
 }
 
 func (fake *FakeS3Client) recordInvocation(key string, args []interface{}) {

--- a/in/command.go
+++ b/in/command.go
@@ -135,6 +135,19 @@ func (command *Command) Run(destinationDir string, request Request) (Response, e
 				}
 			}
 		}
+
+		if request.Params.DownloadTags {
+			err = command.downloadTags(
+				request.Source.Bucket,
+				remotePath,
+				versionID,
+				destinationDir,
+			)
+			if err != nil {
+				return Response{}, err
+			}
+		}
+
 		url = command.urlProvider.GetURL(request, remotePath)
 		if err = command.writeURLFile(destinationDir, url); err != nil {
 			return Response{}, err
@@ -177,6 +190,17 @@ func (command *Command) downloadFile(bucketName string, remotePath string, versi
 	localPath := filepath.Join(destinationDir, destinationFile)
 
 	return command.s3client.DownloadFile(
+		bucketName,
+		remotePath,
+		versionID,
+		localPath,
+	)
+}
+
+func (command *Command) downloadTags(bucketName string, remotePath string, versionID string, destinationDir string) error {
+	localPath := filepath.Join(destinationDir, "tags.json")
+
+	return command.s3client.DownloadTags(
 		bucketName,
 		remotePath,
 		versionID,

--- a/in/models.go
+++ b/in/models.go
@@ -10,6 +10,7 @@ type Request struct {
 
 type Params struct {
 	Unpack       bool   `json:"unpack"`
+	DownloadTags bool   `json:"download_tags"`
 	SkipDownload string `json:"skip_download"`
 }
 

--- a/integration/in_test.go
+++ b/integration/in_test.go
@@ -438,4 +438,68 @@ var _ = Describe("in", func() {
 			Ω(session.Err).Should(gbytes.Say(`'https://no-dots-here' doesn't have enough dots \('.'\), a typical format is 'https://d111111abcdef8.cloudfront.net'`))
 		})
 	})
+
+	Context("when download_tags is true", func() {
+		var (
+			directoryPrefix string
+			tags            map[string]string
+		)
+
+		BeforeEach(func() {
+			directoryPrefix = "in-request-download-tags"
+			inRequest = in.Request{
+				Source: s3resource.Source{
+					AccessKeyID:     accessKeyID,
+					SecretAccessKey: secretAccessKey,
+					SessionToken:    sessionToken,
+					Bucket:          bucketName,
+					RegionName:      regionName,
+					Endpoint:        endpoint,
+					Regexp:          filepath.Join(directoryPrefix, "some-file-(.*)"),
+				},
+				Version: s3resource.Version{
+					Path: filepath.Join(directoryPrefix, "some-file-1"),
+				},
+				Params: in.Params{
+					DownloadTags: true,
+				},
+			}
+
+			err := json.NewEncoder(stdin).Encode(inRequest)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			tempFile, err := ioutil.TempFile("", "file-to-upload")
+			Ω(err).ShouldNot(HaveOccurred())
+			tempFile.Close()
+
+			err = ioutil.WriteFile(tempFile.Name(), []byte("some-file-1"), 0755)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, "some-file-1"), tempFile.Name(), s3resource.NewUploadFileOptions())
+			Ω(err).ShouldNot(HaveOccurred())
+
+			err = os.Remove(tempFile.Name())
+			Ω(err).ShouldNot(HaveOccurred())
+
+			tags = map[string]string{"tag1": "value1", "tag2": "value2"}
+			err = s3client.SetTags(bucketName, filepath.Join(directoryPrefix, "some-file-1"), "", tags)
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			err := s3client.DeleteFile(bucketName, filepath.Join(directoryPrefix, "some-file-1"))
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+
+		It("writes the tags to tags.json", func() {
+			Ω(filepath.Join(destDir, "tags.json")).Should(BeARegularFile())
+			actualTagsJSON, err := ioutil.ReadFile(filepath.Join(destDir, "tags.json"))
+			Ω(err).ShouldNot(HaveOccurred())
+
+			expectedTagsJSON, err := json.Marshal(tags)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			Ω(actualTagsJSON).Should(MatchJSON(expectedTagsJSON))
+		})
+	})
 })

--- a/integration/s3client_test.go
+++ b/integration/s3client_test.go
@@ -56,6 +56,14 @@ var _ = Describe("S3client", func() {
 			err := s3client.DeleteVersionedFile(versionedBucketName, filepath.Join(directoryPrefix, "file-to-upload-2"), fileTwoVersion)
 			Ω(err).ShouldNot(HaveOccurred())
 		}
+
+		fileThreeVersions, err := s3client.BucketFileVersions(versionedBucketName, filepath.Join(directoryPrefix, "file-to-upload-3"))
+		Ω(err).ShouldNot(HaveOccurred())
+
+		for _, fileThreeVersion := range fileThreeVersions {
+			err := s3client.DeleteVersionedFile(versionedBucketName, filepath.Join(directoryPrefix, "file-to-upload-3"), fileThreeVersion)
+			Ω(err).ShouldNot(HaveOccurred())
+		}
 	})
 
 	It("can interact with buckets", func() {

--- a/integration/s3client_test.go
+++ b/integration/s3client_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -67,6 +68,13 @@ var _ = Describe("S3client", func() {
 		_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "file-to-upload-2"), tempFile.Name(), s3resource.NewUploadFileOptions())
 		Ω(err).ShouldNot(HaveOccurred())
 
+		tags := map[string]string{
+			"tag1": "value1",
+			"tag2": "value2",
+		}
+		err = s3client.SetTags(versionedBucketName, filepath.Join(directoryPrefix, "file-to-upload-1"), "", tags)
+		Ω(err).ShouldNot(HaveOccurred())
+
 		options := s3resource.NewUploadFileOptions()
 		options.ServerSideEncryption = "AES256"
 		_, err = s3client.UploadFile(versionedBucketName, filepath.Join(directoryPrefix, "file-to-upload-3"), tempFile.Name(), options)
@@ -87,6 +95,16 @@ var _ = Describe("S3client", func() {
 		read, err := ioutil.ReadFile(filepath.Join(tempDir, "downloaded-file"))
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(read).Should(Equal([]byte("hello-" + runtime)))
+
+		err = s3client.DownloadTags(versionedBucketName, filepath.Join(directoryPrefix, "file-to-upload-1"), "", filepath.Join(tempDir, "tags.json"))
+		Ω(err).ShouldNot(HaveOccurred())
+
+		expectedTagsJSON, err := json.Marshal(tags)
+		Ω(err).ShouldNot(HaveOccurred())
+
+		actualTagsJSON, err := ioutil.ReadFile(filepath.Join(tempDir, "tags.json"))
+		Ω(err).ShouldNot(HaveOccurred())
+		Ω(actualTagsJSON).Should(MatchJSON(expectedTagsJSON))
 
 		resp, err := s3Service.HeadObject(&s3.HeadObjectInput{
 			Bucket: aws.String(versionedBucketName),


### PR DESCRIPTION
This adds a new param to `in` requests called `download_tags`. It will write the [S3 object tags](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html) as key:value pairs to `tags.json`. It is disabled by default.

The `SetTags` function on `s3client` is currently only used for testing, but it could be used to allow tags to be written in `out` (#119).