### PR TITLE
Add `unpack_into` get param

### DIFF
--- a/PR-description.md
+++ b/PR-description.md
@@ -1,0 +1,84 @@
+⚠️  DO NOT MERGE. STILL TESTING
+
+# Why
+
+When the `s3-resource` pulls an archive whose name changes (for instance, depending on a version number), it is hard to use the extracted content in a task after extracting it with `unpack: true`. This is because the archive's content is extracted into a directory whose name is the base name of the archive, which is dynamic. As far as I can tell, Concourse's `job.plan.task.file` doesn't allow dynamic values, so using this resource to pull down and extract task files is cumbersome.
+
+Let me explain.
+
+# Example
+
+### The S3 bucket
+Imagine you had an s3 bucket called `my-tasks-bucket` with these files:
+- `my-tasks-v2.tar.gz`
+-  `my-tasks-v1.tar.gz`
+
+Imagine further that each of these archives contains two tasks, `task-a.yml` and `task-b.yml`.
+
+### The resource definition
+Imagine that you defined an s3 resource to get files from that bucket
+```yaml
+- name: my-s3-tasks
+  type: s3
+  source:
+    bucket: my-tasks-bucket
+    regexp: my-tasks-(.*).tar.gz
+```
+
+### Using the resource in a task
+Assume we want to use `task-a.yml` in a job. Naturally, you'd `get` the resource (with `unpack: true`) and use the task in the job's plan. It is not that simple.
+
+```yaml
+jobs:
+- name: use-task-from-s3
+  plan:
+  - get: my-s3-tasks
+    params: {unpack: true}
+  - task: task-a
+    file: my-s3-tasks/my-tasks-<???>/task-a.yml 
+   # We don't know the version because it is dynamic. Read on for details. 
+```
+
+We can't determine the directory into which `task-a.yml` will be extracted because the name of the archive file pulled by the s3 resource changes depending on the latest version available in the bucket. One day it could be `my-tasks-v1.tar.gz` and on another day, be `my-tasks-v2.tar.gz`.  
+> Note that `unpack: true` extracts the archive into a directory named after the basename of the archive file. So `my-tasks-v1.tar.gz`'s files will be extracted into `my-s3-tasks/my-tasks-v1`
+
+I tried to parameterize the version in the task definition like so `file: my-s3-bucket/my-tasks-((version))/task-a.yml` but Concourse doesn't like that (doesn't seem to hydrate values in `task.file` definitions. But even if I could, it was a hack.
+
+# What
+1. Introduce a new get param named `unpack_into` (expects string). This allows the user to set the path into which the archive will be extracted, making the extracted file location predictable and hence much easier to use in a task.
+2. Make it so that if you set `unpack_into` to a non-empty string, `unpack` will be set to true. This is for two reasons: 
+    - `unpack_into` doesn't make sense without `unpack: true`
+    - having to set both parameters every time you need to unpack into a custom dir is cumbersome. The name `unpack_into` makes it very clear that unpacking will happen, so it is a bit redundant to add another unpack instruction.
+
+## The result
+This should allow me to:
+
+```yaml
+- name: my-s3-tasks
+  type: s3
+  source:
+    bucket: my-tasks-bucket
+    regexp: my-tasks-(.*).tar.gz
+
+jobs:
+- name: use-task-from-s3
+  plan:
+  - get: my-s3-tasks
+    params:
+      unpack_into: extracted
+  - task: scan
+    file: my-s3-tasks/extracted/task-a.yml
+```
+> The use of `unpack_into: extracted`  "stabilizes" the extraction dir, making it predictable.
+
+One could also extract into the resource dir, making the `task.file` usage even cleaner. (this could be dangerous because it has the potential to overwrite the default files the task puts in the input directory like `version`). It would look something like 
+```yaml
+jobs:
+- name: use-task-from-s3
+  plan:
+  - get: my-s3-tasks
+    params:
+      unpack_into: . # extract directly into my-s3-tasks dir
+  - task: scan
+    file: my-s3-tasks/task-a.yml
+```

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Places the following files in the destination:
 
 * `unpack`: *Optional.* If true and the file is an archive (tar, gzipped tar, other gzipped file, or zip), unpack the file. Gzipped tarballs will be both ungzipped and untarred. It is ignored when `get` is running on the initial version.
 
+* `unpack_into`: *Optional.* If set (to a string) and the file is an archive, unpack the file into a directory whose name is the value of the parameter. Note that setting this paramter auto-sets the `unpack` parameter to `true`, no matter if you set `unpack` to `false` or don't set it at all.
+
 * `download_tags`: *Optional.* Write object tags to `tags.json`. Value needs to be a true/false string.
 
 ### `out`: Upload an object to the bucket.

--- a/in/command.go
+++ b/in/command.go
@@ -246,8 +246,6 @@ func (command *Command) metadata(remotePath string, private bool, url string) []
 }
 
 func extractArchive(mime, filename string, destDir string) error {
-	// destDir := filepath.Dir(filename)
-
 	err := inflate(mime, filename, destDir)
 	if err != nil {
 		return fmt.Errorf("failed to extract archive: %s", err)

--- a/in/command.go
+++ b/in/command.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/concourse/s3-resource"
+	s3resource "github.com/concourse/s3-resource"
 	"github.com/concourse/s3-resource/versions"
 )
 
@@ -257,7 +257,7 @@ func extractArchive(mime, filename string, destDir string) error {
 		}
 
 		if len(fileInfos) != 1 {
-			return fmt.Errorf("%d files found after gunzip; expected 1", len(fileInfos))
+			return fmt.Errorf("\n%d files found after gunzip; expected 1\nTried to extract archive %s with type '%s' into dir: %s", len(fileInfos), filename, mime, destDir)
 		}
 
 		filename = filepath.Join(destDir, fileInfos[0].Name())

--- a/in/command.go
+++ b/in/command.go
@@ -126,7 +126,11 @@ func (command *Command) Run(destinationDir string, request Request) (Response, e
 				request.Params.Unpack = true
 			}
 			if request.Params.Unpack {
-				archiveFilePath := filepath.Join(destinationDir, path.Base(remotePath))
+				destinationPath := filepath.Join(destinationDir, path.Base(remotePath))
+				mime := archiveMimetype(destinationPath)
+				if mime == "" {
+					return Response{}, fmt.Errorf("not an archive: %s", destinationPath)
+				}
 
 				var unpackInto string
 				if request.Params.UnpackInto != "" {
@@ -134,15 +138,10 @@ func (command *Command) Run(destinationDir string, request Request) (Response, e
 					os.Mkdir(customOutputDir, os.ModeDir)
 					unpackInto = customOutputDir
 				} else {
-					unpackInto = filepath.Dir(archiveFilePath)
+					unpackInto = filepath.Dir(destinationPath)
 				}
 
-				mime := archiveMimetype(archiveFilePath)
-				if mime == "" {
-					return Response{}, fmt.Errorf("not an archive: %s", archiveFilePath)
-				}
-
-				err = extractArchive(mime, archiveFilePath, unpackInto)
+				err = extractArchive(mime, destinationPath, unpackInto)
 				if err != nil {
 					return Response{}, err
 				}

--- a/in/command.go
+++ b/in/command.go
@@ -137,11 +137,6 @@ func (command *Command) Run(destinationDir string, request Request) (Response, e
 					unpackInto = filepath.Dir(archiveFilePath)
 				}
 
-				fmt.Printf("\n**** params: Unpack=%t | UnpackInto='%s'", request.Params.Unpack, request.Params.UnpackInto)
-				fmt.Printf("\n     remotePath=%s", remotePath)
-				fmt.Printf("\n     archiveFilePath=%s", archiveFilePath)
-				fmt.Printf("\n     unpacking into: %s\n", unpackInto)
-
 				mime := archiveMimetype(archiveFilePath)
 				if mime == "" {
 					return Response{}, fmt.Errorf("not an archive: %s", archiveFilePath)

--- a/in/models.go
+++ b/in/models.go
@@ -10,6 +10,7 @@ type Request struct {
 
 type Params struct {
 	Unpack       bool   `json:"unpack"`
+	UnpackInto	 string `json:"unpack_into"`
 	DownloadTags bool   `json:"download_tags"`
 	SkipDownload string `json:"skip_download"`
 }

--- a/in/models.go
+++ b/in/models.go
@@ -10,7 +10,7 @@ type Request struct {
 
 type Params struct {
 	Unpack       bool   `json:"unpack"`
-	UnpackInto	 string `json:"unpack_into"`
+	UnpackInto   string `json:"unpack_into"`
 	DownloadTags bool   `json:"download_tags"`
 	SkipDownload string `json:"skip_download"`
 }


### PR DESCRIPTION
⚠️  DO NOT MERGE. STILL TESTING

# Why

When the `s3-resource` pulls an archive whose name changes (for instance, depending on a version number), it is hard to use the extracted content in a task after extracting it with `unpack: true`. This is because the archive's content is extracted into a directory whose name is the base name of the archive, which is dynamic. As far as I can tell, Concourse's `job.plan.task.file` doesn't allow dynamic values, so using this resource to pull down and extract task files is cumbersome.

Let me explain.

# Example

### The S3 bucket
Imagine you had an s3 bucket called `my-tasks-bucket` with these files:
- `my-tasks-v2.tar.gz`
-  `my-tasks-v1.tar.gz`

Imagine further that each of these archives contains two tasks, `task-a.yml` and `task-b.yml`.

### The resource definition
Imagine that you defined an s3 resource to get files from that bucket
```yaml
- name: my-s3-tasks
  type: s3
  source:
    bucket: my-tasks-bucket
    regexp: my-tasks-(.*).tar.gz
```

### Using the resource in a task
Assume we want to use `task-a.yml` in a job. Naturally, you'd `get` the resource (with `unpack: true`) and use the task in the job's plan. It is not that simple.

```yaml
jobs:
- name: use-task-from-s3
  plan:
  - get: my-s3-tasks
    params: {unpack: true}
  - task: task-a
    file: my-s3-tasks/my-tasks-<???>/task-a.yml 
   # We don't know the version because it is dynamic. Read on for details. 
```

We can't determine the directory into which `task-a.yml` will be extracted because the name of the archive file pulled by the s3 resource changes depending on the latest version available in the bucket. One day it could be `my-tasks-v1.tar.gz` and on another day, be `my-tasks-v2.tar.gz`.  
> Note that `unpack: true` extracts the archive into a directory named after the basename of the archive file. So `my-tasks-v1.tar.gz`'s files will be extracted into `my-s3-tasks/my-tasks-v1`

I tried to parameterize the version in the task definition like so `file: my-s3-bucket/my-tasks-((version))/task-a.yml` but Concourse doesn't like that (doesn't seem to hydrate values in `task.file` definitions. But even if I could, it was a hack.

# What
1. Introduce a new get param named `unpack_into` (expects string). This allows the user to set the path into which the archive will be extracted, making the extracted file location predictable and hence much easier to use in a task.
2. Make it so that if you set `unpack_into` to a non-empty string, `unpack` will be set to true. This is for two reasons: 
    - `unpack_into` doesn't make sense without `unpack: true`
    - having to set both parameters every time you need to unpack into a custom dir is cumbersome. The name `unpack_into` makes it very clear that unpacking will happen, so it is a bit redundant to add another unpack instruction.

## The result
This should allow me to:

```yaml
- name: my-s3-tasks
  type: s3
  source:
    bucket: my-tasks-bucket
    regexp: my-tasks-(.*).tar.gz

jobs:
- name: use-task-from-s3
  plan:
  - get: my-s3-tasks
    params:
      unpack_into: extracted
  - task: scan
    file: my-s3-tasks/extracted/task-a.yml
```
> The use of `unpack_into: extracted`  "stabilizes" the extraction dir, making it predictable.

One could also extract into the resource dir, making the `task.file` usage even cleaner. (this could be dangerous because it has the potential to overwrite the default files the task puts in the input directory like `version`). It would look something like 
```yaml
jobs:
- name: use-task-from-s3
  plan:
  - get: my-s3-tasks
    params:
      unpack_into: . # extract directly into my-s3-tasks dir
  - task: scan
    file: my-s3-tasks/task-a.yml
```