### PR TITLE
feat: explicitly set USER root

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -14,6 +14,7 @@ RUN set -e; for pkg in $(go list ./...); do \
 	done
 
 FROM ${base_image} AS resource
+USER root
 RUN apt update && apt upgrade -y -o Dpkg::Options::="--force-confdef"
 RUN apt update \
       && apt install -y --no-install-recommends \


### PR DESCRIPTION
- paketo doesn't have a default user root

Authored-by: Preethi Varambally <pvarambally@vmware.com>