### PR TITLE
Multi-architecture support for s3-resource Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,25 @@
-ARG base_image
-ARG builder_image=concourse/golang-builder
+ARG base_image=cgr.dev/chainguard/wolfi-base
+ARG builder_image=cgr.dev/chainguard/go
 
-FROM ${builder_image} as builder
-COPY . /go/src/github.com/concourse/s3-resource
+ARG TARGETOS
+ARG TARGETARCH
+ARG GOAMD64=v3
+ARG GOARM64=v8.2
+
+FROM --platform=$BUILDPLATFORM ${builder_image} AS builder
 WORKDIR /go/src/github.com/concourse/s3-resource
-ENV CGO_ENABLED 0
+COPY . .
 RUN go mod download
-RUN go build -o /assets/in ./cmd/in
-RUN go build -o /assets/out ./cmd/out
-RUN go build -o /assets/check ./cmd/check
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOAMD64=${GOAMD64} GOARM64=${GOARM64} go build -o /assets/in ./cmd/in
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOAMD64=${GOAMD64} GOARM64=${GOARM64} go build -o /assets/out ./cmd/out
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOAMD64=${GOAMD64} GOARM64=${GOARM64} go build -o /assets/check ./cmd/check
 RUN set -e; for pkg in $(go list ./...); do \
 		go test -o "/tests/$(basename $pkg).test" -c $pkg; \
 	done
 
 FROM ${base_image} AS resource
-USER root
-RUN apt update && apt upgrade -y -o Dpkg::Options::="--force-confdef"
-RUN apt update \
-      && apt install -y --no-install-recommends \
-        tzdata \
-        ca-certificates \
-        unzip \
-        zip \
-      && rm -rf /var/lib/apt/lists/*
-COPY --from=builder assets/ /opt/resource/
+RUN apk add --no-cache tzdata ca-certificates unzip zip
+COPY --from=builder /assets/ /opt/resource/
 RUN chmod +x /opt/resource/*
 
 FROM resource AS tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,26 @@
 ARG base_image=cgr.dev/chainguard/wolfi-base
-ARG builder_image=cgr.dev/chainguard/go
+ARG builder_image=concourse/golang-builder
 
-ARG TARGETOS
-ARG TARGETARCH
-ARG GOAMD64=v3
-ARG GOARM64=v8.2
-
-FROM --platform=$BUILDPLATFORM ${builder_image} AS builder
+FROM ${builder_image} as builder
 WORKDIR /go/src/github.com/concourse/s3-resource
 COPY . .
 RUN go mod download
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOAMD64=${GOAMD64} GOARM64=${GOARM64} go build -o /assets/in ./cmd/in
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOAMD64=${GOAMD64} GOARM64=${GOARM64} go build -o /assets/out ./cmd/out
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOAMD64=${GOAMD64} GOARM64=${GOARM64} go build -o /assets/check ./cmd/check
-RUN set -e; for pkg in $(go list ./...); do \
+RUN go build -o /assets/in ./cmd/in
+RUN go build -o /assets/out ./cmd/out
+RUN go build -o /assets/check ./cmd/check
+RUN set -e; for pkg in "$(go list ./...)"; do \
 		go test -o "/tests/$(basename $pkg).test" -c $pkg; \
 	done
 
 FROM ${base_image} AS resource
-RUN apk add --no-cache tzdata ca-certificates unzip zip
-COPY --from=builder /assets/ /opt/resource/
+RUN apk --no-cache add \
+    ca-certificates \
+    tzdata \
+    unzip \
+    zip && \
+    rm -rf /var/cache/apk/*
+
+COPY --from=builder assets/ /opt/resource/
 RUN chmod +x /opt/resource/*
 
 FROM resource AS tests

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ will stop the build.
 Run the tests with the following command:
 
 ```sh
-docker build -t s3-resource --target tests --build-arg base_image=paketobuildpacks/run-jammy-base:latest .
+docker build -t s3-resource --target tests .
 ```
 
 #### Integration tests


### PR DESCRIPTION
Related to https://github.com/concourse/concourse/issues/9183

Updated the Dockerfile to support multi-architecture builds. Key changes:
- ~~Added TARGETOS and TARGETARCH arguments for cross-compilation~~
- ~~Set builder to use BUILDPLATFORM for faster builds~~
- ~~Configured Go builds with explicit GOOS/GOARCH for target platforms~~
- Updated package management for Chainguard base image
- Maintained test execution in the appropriate target environment

This enables building the s3-resource container for multiple architectures (amd64, arm64, etc.) from a single build pipeline.