### PR TITLE
Fix using s3 resource in combination with AWS_CA_BUNDLE option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ version numbers.
 * `skip_ssl_verification`: *Optional.* Skip SSL verification for S3 endpoint.
     Useful for S3 compatible providers using self-signed SSL certificates.
 
+* `ca_bundle`: *Optional.* Set of PEM encoded certificates to validate the S3
+    endpoint against. Useful for S3 compatible providers using self-signed
+    SSL certificates.
+
 * `skip_download`: *Optional.* Skip downloading object from S3. Useful only
     trigger the pipeline without using the object.
 
@@ -291,4 +295,3 @@ In addition to the required permissions above, the `s3:PutObjectTagging` permiss
 
 Please make all pull requests to the `master` branch and ensure tests pass
 locally.
-

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -19,6 +19,7 @@ func main() {
 		request.Source.AwsRoleARN,
 		request.Source.RegionName,
 		request.Source.SkipSSLVerification,
+		request.Source.CABundle,
 		request.Source.UseAwsCredsProvider,
 	)
 	if err != nil {

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -26,6 +26,7 @@ func main() {
 		request.Source.AwsRoleARN,
 		request.Source.RegionName,
 		request.Source.SkipSSLVerification,
+		request.Source.CABundle,
 		request.Source.UseAwsCredsProvider,
 	)
 	if err != nil {

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -26,6 +26,7 @@ func main() {
 		request.Source.AwsRoleARN,
 		request.Source.RegionName,
 		request.Source.SkipSSLVerification,
+		request.Source.CABundle,
 		request.Source.UseAwsCredsProvider,
 	)
 	if err != nil {

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -76,6 +76,7 @@ func getSessionTokenS3Client(awsConfig *aws.Config) (*s3.Client, s3resource.S3Cl
 		awsRoleARN,
 		regionName,
 		false,
+		"",
 		false,
 	)
 	Ω(err).ShouldNot(HaveOccurred())
@@ -129,6 +130,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 			awsRoleARN,
 			regionName,
 			false,
+			"",
 			false,
 		)
 		Ω(err).ShouldNot(HaveOccurred())

--- a/models.go
+++ b/models.go
@@ -19,6 +19,7 @@ type Source struct {
 	SSEKMSKeyId          string `json:"sse_kms_key_id"`
 	UseV2Signing         bool   `json:"use_v2_signing"`
 	SkipSSLVerification  bool   `json:"skip_ssl_verification"`
+	CABundle             string `json:"ca_bundle"`
 	SkipDownload         bool   `json:"skip_download"`
 	InitialVersion       string `json:"initial_version"`
 	InitialPath          string `json:"initial_path"`
@@ -39,6 +40,10 @@ func (source Source) IsValid() (bool, string) {
 
 	if source.VersionedFile != "" && source.InitialPath != "" {
 		return false, "please use initial_version when versioned_file is set"
+	}
+
+	if source.SkipSSLVerification && source.CABundle != "" {
+		return false, "please do not use ca_bundle when skip_ssl_verification is set"
 	}
 
 	if source.InitialContentText != "" && source.InitialContentBinary != "" {

--- a/s3client.go
+++ b/s3client.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
@@ -132,13 +133,14 @@ func NewAwsConfig(
 		regionName = "us-east-1"
 	}
 
-	var httpClient *http.Client
+	httpClient := awshttp.NewBuildableClient()
 	if skipSSLVerification {
-		httpClient = &http.Client{Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}}
-	} else {
-		httpClient = http.DefaultClient
+		httpClient = httpClient.WithTransportOptions(func(tr *http.Transport) {
+			if tr.TLSClientConfig == nil {
+				tr.TLSClientConfig = &tls.Config{}
+			}
+			tr.TLSClientConfig.InsecureSkipVerify = true
+		})
 	}
 
 	cfg, err := config.LoadDefaultConfig(context.Background(),

--- a/s3client_test.go
+++ b/s3client_test.go
@@ -1,10 +1,14 @@
 package s3resource_test
 
 import (
+	"bytes"
 	"context"
-	"net/http"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	s3resource "github.com/concourse/s3-resource"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -64,11 +68,21 @@ var _ = Describe("AWSConfig", func() {
 			Expect(cfg.Region).To(Equal("us-east-1"))
 		})
 
-		It("uses the default http client", func() {
+		It("uses aws buildable http client", func() {
 			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", false, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg).ToNot(BeNil())
-			Expect(cfg.HTTPClient).To(Equal(http.DefaultClient))
+			_, ok := cfg.HTTPClient.(*awshttp.BuildableClient)
+			Expect(ok).To(BeTrue())
+		})
+
+		It("does not skip ssl verification", func() {
+			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", false, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg).ToNot(BeNil())
+			client, ok := cfg.HTTPClient.(*awshttp.BuildableClient)
+			Expect(ok).To(BeTrue())
+			Expect(client.GetTransport().TLSClientConfig.InsecureSkipVerify).To(BeFalse())
 		})
 	})
 
@@ -82,16 +96,75 @@ var _ = Describe("AWSConfig", func() {
 	})
 
 	Context("SSL verification is skipped", func() {
-		It("creates a http client that skips SSL verification", func() {
+		It("creates an http client that skips SSL verification", func() {
 			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", true, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg).ToNot(BeNil())
 
-			client, ok := cfg.HTTPClient.(*http.Client)
+			client, ok := cfg.HTTPClient.(*awshttp.BuildableClient)
 			Expect(ok).To(BeTrue())
-			transport, ok := client.Transport.(*http.Transport)
+			Expect(client.GetTransport().TLSClientConfig.InsecureSkipVerify).To(BeTrue())
+		})
+	})
+
+	Context("AWS_CA_BUNDLE is respected", func() {
+		certificate := []byte("\n" +
+			"-----BEGIN CERTIFICATE-----\n" +
+			"MIIBrzCCAVmgAwIBAgIUbRo9f/LeC0cHVW708dsPek2H2qAwDQYJKoZIhvcNAQEL\n" +
+			"BQAwLzELMAkGA1UEBhMCR0IxIDAeBgNVBAMMF1Rlc3RDZXJ0aWZpY2F0ZS5pbnZh\n" +
+			"bGlkMB4XDTI1MDUzMDEwMTY1OFoXDTI2MDUzMDEwMTY1OFowLzELMAkGA1UEBhMC\n" +
+			"R0IxIDAeBgNVBAMMF1Rlc3RDZXJ0aWZpY2F0ZS5pbnZhbGlkMFwwDQYJKoZIhvcN\n" +
+			"AQEBBQADSwAwSAJBAOflTXmxKBPrQdergC/3iClfXdXl6tATr+i3u8CTeBjWngRE\n" +
+			"QThS/arGhZVeQ++BBwfa2RRXcqQuvKdZaBrVxGUCAwEAAaNNMEswHQYDVR0OBBYE\n" +
+			"FEZCf4s5sbaCGpaRnKvjIWPMBsj6MB8GA1UdIwQYMBaAFEZCf4s5sbaCGpaRnKvj\n" +
+			"IWPMBsj6MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADQQB0JwVRCCKFh4vxJToC\n" +
+			"53Q2e9QuhKrRGtsLvaPOq0CLAlQBV+ufRl92CYblmpo6mINspqYzrOPRlcNk3kiu\n" +
+			"57So\n" +
+			"-----END CERTIFICATE-----\n")
+
+		defer BeforeEach(func() {
+			bundleFile, err := os.CreateTemp("", "certbundle")
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = bundleFile.Write(certificate)
+			Expect(err).NotTo(HaveOccurred())
+
+			origCABundle := os.Getenv("AWS_CA_BUNDLE")
+			err = os.Setenv("AWS_CA_BUNDLE", bundleFile.Name())
+			Expect(err).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				err := os.Setenv("AWS_CA_BUNDLE", origCABundle)
+				Expect(err).NotTo(HaveOccurred())
+				err = os.Remove(bundleFile.Name())
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		It("creates an http client that respects the AWS_CA_BUNDLE option", func() {
+			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", false, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg).ToNot(BeNil())
+
+			block, _ := pem.Decode(certificate)
+			Expect(block).ToNot(BeNil())
+			Expect(block.Type).To(Equal("CERTIFICATE"))
+
+			crt, err := x509.ParseCertificate(block.Bytes)
+			Expect(err).ToNot(HaveOccurred())
+
+			client, ok := cfg.HTTPClient.(*awshttp.BuildableClient)
 			Expect(ok).To(BeTrue())
-			Expect(transport.TLSClientConfig.InsecureSkipVerify).To(BeTrue())
+			subjs := client.GetTransport().TLSClientConfig.RootCAs.Subjects()
+
+			found := false
+			for _, v := range subjs {
+				if bytes.Equal(v, crt.RawSubject) {
+					found = true
+					break
+				}
+			}
+			Expect(found).To(BeTrue())
 		})
 	})
 })

--- a/s3client_test.go
+++ b/s3client_test.go
@@ -20,7 +20,7 @@ var _ = Describe("AWSConfig", func() {
 			accessKey := "access-key"
 			secretKey := "secret-key"
 			sessionToken := "session-token"
-			cfg, err := s3resource.NewAwsConfig(accessKey, secretKey, sessionToken, "", "", false, false)
+			cfg, err := s3resource.NewAwsConfig(accessKey, secretKey, sessionToken, "", "", false, "", false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg).ToNot(BeNil())
 
@@ -35,7 +35,7 @@ var _ = Describe("AWSConfig", func() {
 
 	Context("There are no static credentials or role to assume", func() {
 		It("uses the anonymous credentials", func() {
-			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", false, false)
+			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", false, "", false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg).ToNot(BeNil())
 			Expect(cfg.Credentials).ToNot(BeNil())
@@ -45,7 +45,7 @@ var _ = Describe("AWSConfig", func() {
 
 	Context("Set to use the Aws Default Credential Provider", func() {
 		It("uses the Aws Default Credential Provider", func() {
-			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", false, true)
+			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", false, "", true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg).ToNot(BeNil())
 			Expect(cfg.Credentials).ToNot(BeNil())
@@ -55,21 +55,21 @@ var _ = Describe("AWSConfig", func() {
 
 	Context("default values", func() {
 		It("sets RetryMaxAttempts", func() {
-			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", false, false)
+			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", false, "", false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg).ToNot(BeNil())
 			Expect(cfg.RetryMaxAttempts).To(Equal(s3resource.MaxRetries))
 		})
 
 		It("sets region to us-east-1", func() {
-			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", false, false)
+			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", false, "", false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg).ToNot(BeNil())
 			Expect(cfg.Region).To(Equal("us-east-1"))
 		})
 
 		It("uses aws buildable http client", func() {
-			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", false, false)
+			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", false, "", false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg).ToNot(BeNil())
 			_, ok := cfg.HTTPClient.(*awshttp.BuildableClient)
@@ -77,7 +77,7 @@ var _ = Describe("AWSConfig", func() {
 		})
 
 		It("does not skip ssl verification", func() {
-			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", false, false)
+			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", false, "", false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg).ToNot(BeNil())
 			client, ok := cfg.HTTPClient.(*awshttp.BuildableClient)
@@ -88,7 +88,7 @@ var _ = Describe("AWSConfig", func() {
 
 	Context("Region is specified", func() {
 		It("sets the region", func() {
-			cfg, err := s3resource.NewAwsConfig("", "", "", "", "ca-central-1", false, false)
+			cfg, err := s3resource.NewAwsConfig("", "", "", "", "ca-central-1", false, "", false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg).ToNot(BeNil())
 			Expect(cfg.Region).To(Equal("ca-central-1"))
@@ -97,7 +97,7 @@ var _ = Describe("AWSConfig", func() {
 
 	Context("SSL verification is skipped", func() {
 		It("creates an http client that skips SSL verification", func() {
-			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", true, false)
+			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", true, "", false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg).ToNot(BeNil())
 
@@ -107,7 +107,7 @@ var _ = Describe("AWSConfig", func() {
 		})
 	})
 
-	Context("AWS_CA_BUNDLE is respected", func() {
+	Context("AWS_CA_BUNDLE environment variable is respected", func() {
 		certificate := []byte("\n" +
 			"-----BEGIN CERTIFICATE-----\n" +
 			"MIIBrzCCAVmgAwIBAgIUbRo9f/LeC0cHVW708dsPek2H2qAwDQYJKoZIhvcNAQEL\n" +
@@ -141,12 +141,54 @@ var _ = Describe("AWSConfig", func() {
 			})
 		})
 
-		It("creates an http client that respects the AWS_CA_BUNDLE option", func() {
-			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", false, false)
+		It("creates an http client that respects the AWS_CA_BUNDLE environment variable", func() {
+			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", false, "", false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg).ToNot(BeNil())
 
 			block, _ := pem.Decode(certificate)
+			Expect(block).ToNot(BeNil())
+			Expect(block.Type).To(Equal("CERTIFICATE"))
+
+			crt, err := x509.ParseCertificate(block.Bytes)
+			Expect(err).ToNot(HaveOccurred())
+
+			client, ok := cfg.HTTPClient.(*awshttp.BuildableClient)
+			Expect(ok).To(BeTrue())
+			subjs := client.GetTransport().TLSClientConfig.RootCAs.Subjects()
+
+			found := false
+			for _, v := range subjs {
+				if bytes.Equal(v, crt.RawSubject) {
+					found = true
+					break
+				}
+			}
+			Expect(found).To(BeTrue())
+		})
+	})
+
+	Context("caBundle option is respected", func() {
+		certificate := "\n" +
+			"-----BEGIN CERTIFICATE-----\n" +
+			"MIIBrzCCAVmgAwIBAgIUbRo9f/LeC0cHVW708dsPek2H2qAwDQYJKoZIhvcNAQEL\n" +
+			"BQAwLzELMAkGA1UEBhMCR0IxIDAeBgNVBAMMF1Rlc3RDZXJ0aWZpY2F0ZS5pbnZh\n" +
+			"bGlkMB4XDTI1MDUzMDEwMTY1OFoXDTI2MDUzMDEwMTY1OFowLzELMAkGA1UEBhMC\n" +
+			"R0IxIDAeBgNVBAMMF1Rlc3RDZXJ0aWZpY2F0ZS5pbnZhbGlkMFwwDQYJKoZIhvcN\n" +
+			"AQEBBQADSwAwSAJBAOflTXmxKBPrQdergC/3iClfXdXl6tATr+i3u8CTeBjWngRE\n" +
+			"QThS/arGhZVeQ++BBwfa2RRXcqQuvKdZaBrVxGUCAwEAAaNNMEswHQYDVR0OBBYE\n" +
+			"FEZCf4s5sbaCGpaRnKvjIWPMBsj6MB8GA1UdIwQYMBaAFEZCf4s5sbaCGpaRnKvj\n" +
+			"IWPMBsj6MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADQQB0JwVRCCKFh4vxJToC\n" +
+			"53Q2e9QuhKrRGtsLvaPOq0CLAlQBV+ufRl92CYblmpo6mINspqYzrOPRlcNk3kiu\n" +
+			"57So\n" +
+			"-----END CERTIFICATE-----\n"
+
+		It("creates an http client that respects the caBundle option", func() {
+			cfg, err := s3resource.NewAwsConfig("", "", "", "", "", false, certificate, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg).ToNot(BeNil())
+
+			block, _ := pem.Decode([]byte(certificate))
 			Expect(block).ToNot(BeNil())
 			Expect(block.Type).To(Equal("CERTIFICATE"))
 


### PR DESCRIPTION
The [AWS_CA_BUNDLE](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html#envvars-list-AWS_CA_BUNDLE) environment variable can be used within the AWS SDK to set a custom CA bundle
This is particularly useful with custom S3 compatible endpoints.

Currently, if the AWS_CA_BUNDLE environment variable is set, the s3 resource will fail:
```
# cat input.json | /opt/resource/check
error error creating aws config: unable to add custom RootCAs HTTPClient, has no WithTransportOptions, *http.Client
```

This occurs because the AWS Go SDK v2 expects AWS's HTTP client to always be an `awshttp.BuildableClient`: https://github.com/aws/aws-sdk-go-v2/blob/c69bd7e10c45c4625623d29f4c7b3889188029e1/config/resolve.go#L57-L61

This pull request updates the S3 resource to use an `awshttp.BuildableClient` rather than a `http.Client`, while maintaining the same functionality, including the option to skip verifying TLS certificates.

We have updated the tests to ensure this functionality remains, and added a new test to verify that the updated code is usable with the `AWS_CA_BUNDLE` environment variable.