### PR TITLE
Fix handling of zero length files

### DIFF
--- a/s3client.go
+++ b/s3client.go
@@ -323,6 +323,12 @@ func (client *s3client) UploadFile(bucketName string, remotePath string, localPa
 		return "", err
 	}
 
+	// Have to manually complete the progress bar for empty files
+	// See https://github.com/vbauerster/mpb/issues/7
+	if fSize == 0 {
+		progress.SetTotal(-1, true)
+	}
+
 	if uploadOutput.VersionID != nil {
 		return *uploadOutput.VersionID, nil
 	}
@@ -368,6 +374,12 @@ func (client *s3client) DownloadFile(bucketName string, remotePath string, versi
 	_, err = downloader.Download(context.TODO(), progressWriterAt{localFile, progress.ProxyWriter(io.Discard)}, getObject)
 	if err != nil {
 		return err
+	}
+
+	// Have to manually complete the progress bar for empty files
+	// See https://github.com/vbauerster/mpb/issues/7
+	if *object.ContentLength == 0 {
+		progress.SetTotal(-1, true)
 	}
 
 	return nil


### PR DESCRIPTION
Hello,

There appears to have recently been a regression in the S3 resource type due to the new progress bar code, where uploading or downloading a zero length file will cause the resource type to hang.
This is a documented issue with the progress bar library: https://github.com/vbauerster/mpb/issues/7
The solution is to manually mark the progress bar as complete with 0 length files.

We were unable to implement tests for this behaviour as the testing framework does not allow mocking the AWS Go SDK, only the s3 resource s3client, which is where the behaviour that needs to be tested is.
We have instead performed manual testing which was successful.