### PR TITLE
Add skip_s3_checksums parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ version numbers.
 * `use_path_style`: *Optional.* Enables legacy path-style access for S3
     compatible providers. The default behavior is virtual path-style.
 
+* `skip_s3_checksums`: *Optional.* Enables legacy optional checksum validation
+    for S3 compatible providers. The default behaviour is to require checksum
+    verification.
+
 ### File Names
 
 One of the following two options must be specified:

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -32,6 +32,7 @@ func main() {
 		request.Source.Endpoint,
 		request.Source.DisableSSL,
 		request.Source.UsePathStyle,
+		request.Source.SkipS3Checksums,
 	)
 	if err != nil {
 		s3resource.Fatal("error creating s3 client", err)

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -44,6 +44,7 @@ func main() {
 		endpoint,
 		request.Source.DisableSSL,
 		request.Source.UsePathStyle,
+		request.Source.SkipS3Checksums,
 	)
 	if err != nil {
 		s3resource.Fatal("error creating s3 client", err)

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -39,6 +39,7 @@ func main() {
 		request.Source.Endpoint,
 		request.Source.DisableSSL,
 		request.Source.UsePathStyle,
+		request.Source.SkipS3Checksums,
 	)
 	if err != nil {
 		s3resource.Fatal("error creating s3 client", err)

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -32,6 +32,7 @@ var (
 	endpoint            = os.Getenv("S3_ENDPOINT")
 	v2signing           = os.Getenv("S3_V2_SIGNING")
 	pathStyle           = len(os.Getenv("S3_USE_PATH_STYLE")) > 0
+	skipS3Checksums     = len(os.Getenv("S3_SKIP_S3_CHECKSUMS")) > 0
 	awsConfig           *aws.Config
 	s3client            s3resource.S3Client
 	s3Service           *s3.Client
@@ -86,6 +87,7 @@ func getSessionTokenS3Client(awsConfig *aws.Config) (*s3.Client, s3resource.S3Cl
 		endpoint,
 		false,
 		pathStyle,
+		skipS3Checksums,
 	)
 	Ω(err).ShouldNot(HaveOccurred())
 
@@ -142,6 +144,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 			endpoint,
 			false,
 			pathStyle,
+			skipS3Checksums,
 		)
 		Ω(err).ShouldNot(HaveOccurred())
 	}

--- a/models.go
+++ b/models.go
@@ -27,6 +27,7 @@ type Source struct {
 	InitialContentBinary string `json:"initial_content_binary"`
 	DisableMultipart     bool   `json:"disable_multipart"`
 	UsePathStyle         bool   `json:"use_path_style"`
+	SkipS3Checksums      bool   `json:"skip_s3_checksums"`
 }
 
 func (source Source) IsValid() (bool, string) {

--- a/s3client.go
+++ b/s3client.go
@@ -74,7 +74,7 @@ func NewS3Client(
 	progressOutput io.Writer,
 	awsConfig *aws.Config,
 	endpoint string,
-	disableSSL, usePathStyle bool,
+	disableSSL, usePathStyle, skipS3Checksums bool,
 ) (S3Client, error) {
 	s3Opts := []func(*s3.Options){}
 
@@ -96,6 +96,10 @@ func NewS3Client(
 			o.BaseEndpoint = &endpoint
 			o.UsePathStyle = usePathStyle
 			o.DisableLogOutputChecksumValidationSkipped = true
+			if skipS3Checksums {
+				o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+				o.ResponseChecksumValidation = aws.ResponseChecksumValidationWhenRequired
+			}
 		})
 	}
 


### PR DESCRIPTION
We allow to skip the s3 checksum validation. His must be configurable. In order to use the newest s3 client libraries with oci object storage.

Similar changes were introduced in terraform for the same reason: https://github.com/hashicorp/terraform/issues/36704